### PR TITLE
fix: building for alpine

### DIFF
--- a/build/main.yml
+++ b/build/main.yml
@@ -203,13 +203,14 @@ jobs:
       displayName: Build
       env:
         CURRENDIR: $(Build.SourcesDirectory)
-        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g pnpm cross-env && cross-env ARCH=arm64 npm_config_arch=arm64 ARCHIVE_SUFFIX=-armv8 pnpm install && cross-env ARCH=arm64 npm_config_arch=arm64 ARCHIVE_SUFFIX=-armv8 pnpm run prebuild
+        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g pnpm cross-env && cross-env ARCH=arm64 npm_config_arch=arm64 pnpm install && cross-env ARCH=arm64 npm_config_arch=arm64 pnpm run prebuild
       inputs:
         targetType: 'inline'
         workingDirectory: zeromq.js
         script: |
-            docker pull node:18-alpine
-            docker tag node:18-alpine builder
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+            docker pull arm64v8/node:14.16.0-alpine
+            docker tag arm64v8/node:14.16.0-alpine builder
             docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
     - template: artifacts.yml

--- a/build/main.yml
+++ b/build/main.yml
@@ -174,8 +174,8 @@ jobs:
         targetType: 'inline'
         workingDirectory: zeromq.js
         script: |
-            docker pull node:18-alpine
-            docker tag node:18-alpine builder
+            docker pull node:14.16.0-alpine
+            docker tag node:14.16.0-alpine builder
             docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
     - template: artifacts.yml

--- a/build/main.yml
+++ b/build/main.yml
@@ -169,7 +169,7 @@ jobs:
       displayName: Build
       env:
         CURRENDIR: $(Build.SourcesDirectory)
-        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g pnpm && pnpm install && pnpm run prebuild
+        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm install && npm run prebuild
       inputs:
         targetType: 'inline'
         workingDirectory: zeromq.js
@@ -203,7 +203,7 @@ jobs:
       displayName: Build
       env:
         CURRENDIR: $(Build.SourcesDirectory)
-        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g pnpm cross-env && cross-env ARCH=arm64 npm_config_arch=arm64 pnpm install && cross-env ARCH=arm64 npm_config_arch=arm64 pnpm run prebuild
+        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g cross-env && cross-env ARCH=arm64 npm_config_arch=arm64 npm install && cross-env ARCH=arm64 npm_config_arch=arm64 npm run prebuild
       inputs:
         targetType: 'inline'
         workingDirectory: zeromq.js


### PR DESCRIPTION
* Uses qemu to host arm64 alpine container
* Change the base image to `node:14.16.0-alpine` to align with our current supported build image for VSCode core https://github.com/microsoft/vscode-linux-build-agent/blob/f29bb53bf6d3e673e0fef69e1840a0fb752a99dd/alpine-x64/Dockerfile#L2, so that minimum libstdc++ support is satisfied.