### PR TITLE
feat: add support for windows arm64

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -15,7 +15,7 @@ parameters:
 
 steps:
 - task: NodeTool@0
-  condition: eq('${{ parameters.installNode }}', 'true')
+  condition: eq('${{ parameters.install_node }}', 'true')
   inputs:
     versionSource: 'spec'
     versionSpec: ${{ parameters.node_version }}

--- a/build/build.yml
+++ b/build/build.yml
@@ -3,6 +3,7 @@ parameters:
   tag: ''
   python_arch: 'x64'
   npm_config_arch: 'x64'
+  node_version: '18.x'
   ARCH: 'x64'
   artifact_name: ''
   prebuild_folder_name: ''
@@ -17,7 +18,7 @@ steps:
   condition: eq('${{ parameters.installNode }}', 'true')
   inputs:
     versionSource: 'spec'
-    versionSpec: '18.x'
+    versionSpec: ${{ parameters.node_version }}
 
 - task: UsePythonVersion@0
   condition: eq('${{ parameters.yum_install_python }}', 'false')

--- a/build/main.yml
+++ b/build/main.yml
@@ -41,6 +41,19 @@ jobs:
         output_node_file: 'node.napi.glibc.node'
         test: false
 
+- job: win32_arm64
+  pool:
+    vmImage: 'windows-latest'
+  steps:
+    - template: build.yml
+      parameters:
+        ARCH: arm64
+        npm_config_arch: arm64
+        artifact_name: 'win32-arm64'
+        prebuild_folder_name: 'win32-arm64'
+        output_node_file: 'node.napi.glibc.node'
+        test: false
+
 - job: darwin_x64
   pool:
     vmImage: 'macOS-latest'

--- a/build/main.yml
+++ b/build/main.yml
@@ -49,6 +49,7 @@ jobs:
       parameters:
         ARCH: arm64
         npm_config_arch: arm64
+        node_version: '19.x'
         artifact_name: 'win32-arm64'
         prebuild_folder_name: 'win32-arm64'
         output_node_file: 'node.napi.glibc.node'

--- a/build/patch.patch
+++ b/build/patch.patch
@@ -11,7 +11,7 @@ index 68a8f58..280b468 100644
              }],
  
 diff --git a/package.json b/package.json
-index 058ecd1..12fcd8a 100644
+index 058ecd1..cd2e3d9 100644
 --- a/package.json
 +++ b/package.json
 @@ -20,7 +20,7 @@
@@ -23,6 +23,14 @@ index 058ecd1..12fcd8a 100644
      "shelljs": "^0.8.5",
      "shx": "^0.3.4"
    },
+@@ -35,7 +35,6 @@
+     "@types/which": "^2.0.1",
+     "benchmark": "^2.1.4",
+     "chai": "^4.3.7",
+-    "deasync": "^0.1.28",
+     "downlevel-dts": "^0.11.0",
+     "electron-mocha": "^11.0.2",
+     "eslint-config-atomic": "^1.18.1",
 diff --git a/script/build.ts b/script/build.ts
 index c055ebc..693d914 100644
 --- a/script/build.ts


### PR DESCRIPTION
* Updates to Node v19 for Windows arm64. It is first official version that has support for this target.
* https://github.com/microsoft/zeromq-prebuilt/pull/21/commits/b975af3f487fb9aac04315362c95156fb1d14a10 removes `deasync` from dependency because it breaks build with newer gyp version very likely due to this hack https://github.com/abbr/deasync/blob/d92c0e23e70510e32b49007aa523e9c38b94b9b7/binding.gyp#L25, the module should replace with `<!(node -p \"require('node-addon-api').include_dir\")` instead. Also, the dependency is only used when calling into a deprecated API in `Zeromq.js` https://github.com/zeromq/zeromq.js/blob/43a94beab1faf80a2e1b059ab0bbe063c4d76efc/src/compat.ts#L438-L451. If Jupyter extension does not call into it, this change should be safe.