### PR TITLE
chore: migrate to 1ESPT

### DIFF
--- a/build/artifacts.yml
+++ b/build/artifacts.yml
@@ -47,9 +47,3 @@ steps:
   condition: and(succeeded(), contains('${{ parameters.artifact_name }}', 'win32'))
   env:
     TARGET: ${{ parameters.prebuild_folder_name }}
-
-- task: PublishPipelineArtifact@0
-  displayName: 'Publish Pipeline Artifact'
-  inputs:
-    artifactName: ${{ parameters.artifact_name }}
-    targetPath: $(Build.ArtifactStagingDirectory)

--- a/build/build.yml
+++ b/build/build.yml
@@ -55,6 +55,32 @@ steps:
   displayName: Patch zeromq.js
   workingDirectory: zeromq.js
 
+- pwsh: |
+    $includes = @'
+      {
+        'target_defaults': {
+          'conditions': [
+            ['OS=="win"', {
+              'msvs_settings': {
+                'VCLinkerTool': {
+                  'AdditionalOptions': [
+                    '/profile'
+                  ]
+                }
+              }
+            }]
+          ]
+        }
+      }
+    '@
+
+    if (!(Test-Path "~/.gyp")) {
+      mkdir "~/.gyp"
+      echo $includes > "~/.gyp/include.gypi"
+    }
+  displayName: Create include.gypi
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
 - bash: |
     export PREBUILD_STRIP_BIN=$STRIP
     npm install
@@ -75,6 +101,37 @@ steps:
   workingDirectory: zeromq.js
   env:
     npm_config_arch: ${{ parameters.npm_config_arch }}
+
+- task: CopyFiles@2
+  inputs:
+    Contents: |
+      zeromq.js/prebuilds/${{ parameters.prebuild_folder_name }}/${{ parameters.output_node_file }}
+      zeromq.js/build/libzmq/bin/*.dll
+      zeromq.js/**/*.pdb
+    TargetFolder: $(Agent.TempDirectory)/apiscan
+  displayName: Copy files to APIScan dir
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- task: APIScan@2
+  inputs:
+    softwareFolder: $(Agent.TempDirectory)/apiscan
+    softwareName: 'zeromq'
+    softwareVersionNum: '1'
+    isLargeApp: false
+    toolVersion: 'Latest'
+  displayName: Run APIScan
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  env:
+    AzureServicesAuthConnectionString: $(apiscan-connectionstring)
+
+- task: PublishSecurityAnalysisLogs@3
+  inputs:
+    ArtifactName: 'CodeAnalysisLogs'
+    ArtifactType: 'Container'
+    AllTools: true
+    ToolLogsNotFoundAction: 'Standard'
+  displayName: Publish security logs
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - ${{ if eq(parameters.build, true) }}:
   - template: artifacts.yml

--- a/build/build.yml
+++ b/build/build.yml
@@ -79,7 +79,7 @@ steps:
       echo $includes > "~/.gyp/include.gypi"
     }
   displayName: Create include.gypi
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
 
 - bash: |
     export PREBUILD_STRIP_BIN=$STRIP
@@ -110,7 +110,7 @@ steps:
       zeromq.js/**/*.pdb
     TargetFolder: $(Agent.TempDirectory)/apiscan
   displayName: Copy files to APIScan dir
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
 
 - task: APIScan@2
   inputs:
@@ -120,7 +120,7 @@ steps:
     isLargeApp: false
     toolVersion: 'Latest'
   displayName: Run APIScan
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
   env:
     AzureServicesAuthConnectionString: $(apiscan-connectionstring)
 
@@ -131,7 +131,7 @@ steps:
     AllTools: true
     ToolLogsNotFoundAction: 'Standard'
   displayName: Publish security logs
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
 
 - ${{ if eq(parameters.build, true) }}:
   - template: artifacts.yml

--- a/build/build_apiscan.yml
+++ b/build/build_apiscan.yml
@@ -110,8 +110,8 @@ steps:
 - task: APIScan@2
   inputs:
     softwareFolder: $(Agent.TempDirectory)/apiscan
-    softwareName: 'zeromq'
-    softwareVersionNum: '1'
+    softwareName: 'vscode-zeromq-prebuilt'
+    softwareVersionNum: '0.2'
     isLargeApp: false
     toolVersion: 'Latest'
   displayName: Run APIScan

--- a/build/main.yml
+++ b/build/main.yml
@@ -10,6 +10,10 @@ resources:
       name: microsoft/vscode-engineering
       ref: main
       endpoint: Monaco
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
 
 parameters:
   - name: testGitHubRelease
@@ -17,203 +21,200 @@ parameters:
     type: boolean
     default: false
 
-jobs:
-- job: win32_x64
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-    - template: build.yml
-      parameters:
-        artifact_name: 'win32-x64'
-        prebuild_folder_name: 'win32-x64'
-        output_node_file: 'node.napi.glibc.node'
-
-- job: win32_x64_apiscan
-  variables:
-    - group: 'API Scan'
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-    - template: build_apiscan.yml
-      parameters:
-        prebuild_folder_name: 'win32-x64'
-        output_node_file: 'node.napi.glibc.node'
-
-- job: win32_arm64
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-    - template: build.yml
-      parameters:
-        ARCH: arm64
-        npm_config_arch: arm64
-        node_version: '19.x'
-        artifact_name: 'win32-arm64'
-        prebuild_folder_name: 'win32-arm64'
-        output_node_file: 'node.napi.glibc.node'
-        test: false
-
-- job: darwin_x64
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-    - template: build.yml
-      parameters:
-        ARCH: ''
-        artifact_name: 'darwin-x64'
-        prebuild_folder_name: 'darwin-x64'
-        output_node_file: 'node.napi.glibc.node'
-
-- job: darwin_arm64
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-    - template: build.yml
-      parameters:
-        ARCH: arm64
-        artifact_name: 'darwin-arm64'
-        prebuild_folder_name: 'darwin-arm64'
-        output_node_file: 'node.napi.glibc.node'
-        test: false
-
-- template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
-    jobDisplayName: linux_x64_glibc
-    jobPlatformName: Linux_x64_glibc
-    testNodeVersion: '18.x'
-    timeoutInMinutes: 30
-    testSteps:
-      - template: build.yml
-        parameters:
-          ARCH: x64
-          artifact_name: 'linux-x64'
-          prebuild_folder_name: 'linux-x64'
-          yum_install_python: false
-          install_node: false
-          output_node_file: 'node.napi.glibc.node'
+    sdl:
+        sourceAnalysisPool: 1es-windows-2019-x64
+        tsa:
+          enabled: true
+    stages:
+      - stage: Build
+        jobs:
+          - job: win32_x64
+            pool:
+              name: 1es-windows-2019-x64
+              os: windows
+            steps:
+              - template: build.yml
+                parameters:
+                  artifact_name: 'win32-x64'
+                  prebuild_folder_name: 'win32-x64'
+                  output_node_file: 'node.napi.glibc.node'
 
-- template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-  parameters:
-    jobDisplayName: linux_arm64_glibc
-    jobPlatformName: Linux_arm64_glibc
-    testNodeVersion: '18.x'
-    timeoutInMinutes: 30
-    targetArch: arm64
-    testSteps:
-      - template: build.yml
-        parameters:
-          ARCH: arm64
-          npm_config_arch: arm64
-          ARCHIVE_SUFFIX: -armv8
-          artifact_name: linux-arm64-glibc
-          prebuild_folder_name: 'linux-arm64'
-          yum_install_python: false
-          test: false
-          install_node: false
-          output_node_file: 'node.napi.glibc.node'
+          - job: win32_arm64
+            pool:
+              name: 1es-windows-2019-x64
+              os: windows
+            steps:
+              - template: build.yml
+                parameters:
+                  ARCH: arm64
+                  npm_config_arch: arm64
+                  node_version: '19.x'
+                  artifact_name: 'win32-arm64'
+                  prebuild_folder_name: 'win32-arm64'
+                  output_node_file: 'node.napi.glibc.node'
+                  test: false
 
-- template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-  parameters:
-    jobDisplayName: linux_armhf_glibc
-    jobPlatformName: Linux_armhf_glibc
-    testNodeVersion: '18.x'
-    timeoutInMinutes: 30
-    targetArch: armhf
-    testSteps:
-      - template: build.yml
-        parameters:
-          ARCH: arm
-          npm_config_arch: arm
-          ARCHIVE_SUFFIX: -armv7
-          artifact_name: linux-armhf-glibc
-          prebuild_folder_name: 'linux-arm'
-          yum_install_python: false
-          test: false
-          install_node: false
-          output_node_file: 'node.napi.glibc.node'
+          - job: darwin_x64
+            pool:
+              vmImage: 'macOS-latest'
+              os: macOS
+            steps:
+              - template: build.yml
+                parameters:
+                  ARCH: ''
+                  artifact_name: 'darwin-x64'
+                  prebuild_folder_name: 'darwin-x64'
+                  output_node_file: 'node.napi.glibc.node'
 
-- job: alpine_x64_musl
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: build.yml
-      parameters:
-        build: false
-        test: false
+          - job: darwin_arm64
+            pool:
+              vmImage: 'macOS-latest'
+              os: macOS
+            steps:
+              - template: build.yml
+                parameters:
+                  ARCH: arm64
+                  artifact_name: 'darwin-arm64'
+                  prebuild_folder_name: 'darwin-arm64'
+                  output_node_file: 'node.napi.glibc.node'
+                  test: false
 
-    - task: DockerInstaller@0
-      inputs:
-        dockerVersion: '17.09.0-ce'
+          - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+            parameters:
+              jobDisplayName: linux_x64_glibc
+              jobPlatformName: Linux_x64_glibc
+              testNodeVersion: '18.x'
+              timeoutInMinutes: 30
+              testSteps:
+                - template: build.yml
+                  parameters:
+                    ARCH: x64
+                    artifact_name: 'linux-x64'
+                    prebuild_folder_name: 'linux-x64'
+                    yum_install_python: false
+                    install_node: false
+                    output_node_file: 'node.napi.glibc.node'
 
-    - task: Bash@3
-      displayName: Build
-      env:
-        CURRENDIR: $(Build.SourcesDirectory)
-        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm install && npm run prebuild
-      inputs:
-        targetType: 'inline'
-        workingDirectory: zeromq.js
-        script: |
-            docker pull node:14.16.0-alpine
-            docker tag node:14.16.0-alpine builder
-            docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
+          - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+            parameters:
+              jobDisplayName: linux_arm64_glibc
+              jobPlatformName: Linux_arm64_glibc
+              testNodeVersion: '18.x'
+              timeoutInMinutes: 30
+              targetArch: arm64
+              testSteps:
+                - template: build.yml
+                  parameters:
+                    ARCH: arm64
+                    npm_config_arch: arm64
+                    ARCHIVE_SUFFIX: -armv8
+                    artifact_name: linux-arm64-glibc
+                    prebuild_folder_name: 'linux-arm64'
+                    yum_install_python: false
+                    test: false
+                    install_node: false
+                    output_node_file: 'node.napi.glibc.node'
 
-    - template: artifacts.yml
-      parameters:
-        artifact_name: alpine-x64-musl
-        prebuild_folder_name: 'linux-x64'
-        output_node_file: 'node.napi.musl.node'
-        test: false
+          - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+            parameters:
+              jobDisplayName: linux_armhf_glibc
+              jobPlatformName: Linux_armhf_glibc
+              testNodeVersion: '18.x'
+              timeoutInMinutes: 30
+              targetArch: armhf
+              testSteps:
+                - template: build.yml
+                  parameters:
+                    ARCH: arm
+                    npm_config_arch: arm
+                    ARCHIVE_SUFFIX: -armv7
+                    artifact_name: linux-armhf-glibc
+                    prebuild_folder_name: 'linux-arm'
+                    yum_install_python: false
+                    test: false
+                    install_node: false
+                    output_node_file: 'node.napi.glibc.node'
+
+          - job: alpine_x64_musl
+            pool:
+              vmImage: '1es-ubuntu-22.04-x64'
+              os: linux
+            steps:
+              - template: build.yml
+                parameters:
+                  build: false
+                  test: false
+
+              - task: DockerInstaller@0
+                inputs:
+                  dockerVersion: '17.09.0-ce'
+
+              - task: Bash@3
+                displayName: Build
+                env:
+                  CURRENDIR: $(Build.SourcesDirectory)
+                  DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm install && npm run prebuild
+                inputs:
+                  targetType: 'inline'
+                  workingDirectory: zeromq.js
+                  script: |
+                      docker pull node:14.16.0-alpine
+                      docker tag node:14.16.0-alpine builder
+                      docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
+
+              - template: artifacts.yml
+                parameters:
+                  artifact_name: alpine-x64-musl
+                  prebuild_folder_name: 'linux-x64'
+                  output_node_file: 'node.napi.musl.node'
+                  test: false
 
 
-- job: alpine_arm64_musl
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: build.yml
-      parameters:
-        build: false
-        test: false
+          - job: alpine_arm64_musl
+            pool:
+              vmImage: '1es-ubuntu-22.04-x64'
+              os: linux
+            steps:
+              - template: build.yml
+                parameters:
+                  build: false
+                  test: false
 
-    - task: DockerInstaller@0
-      inputs:
-        dockerVersion: '17.09.0-ce'
+              - task: DockerInstaller@0
+                inputs:
+                  dockerVersion: '17.09.0-ce'
 
-    - task: Bash@3
-      displayName: Build
-      env:
-        CURRENDIR: $(Build.SourcesDirectory)
-        DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g cross-env && cross-env ARCH=arm64 npm_config_arch=arm64 npm install && cross-env ARCH=arm64 npm_config_arch=arm64 npm run prebuild
-      inputs:
-        targetType: 'inline'
-        workingDirectory: zeromq.js
-        script: |
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-            docker pull arm64v8/node:14.16.0-alpine
-            docker tag arm64v8/node:14.16.0-alpine builder
-            docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
+              - task: Bash@3
+                displayName: Build
+                env:
+                  CURRENDIR: $(Build.SourcesDirectory)
+                  DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g cross-env && cross-env ARCH=arm64 npm_config_arch=arm64 npm install && cross-env ARCH=arm64 npm_config_arch=arm64 npm run prebuild
+                inputs:
+                  targetType: 'inline'
+                  workingDirectory: zeromq.js
+                  script: |
+                      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                      docker pull arm64v8/node:14.16.0-alpine
+                      docker tag arm64v8/node:14.16.0-alpine builder
+                      docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
-    - template: artifacts.yml
-      parameters:
-        artifact_name: alpine-arm64-musl
-        prebuild_folder_name: 'linux-arm64'
-        output_node_file: 'node.napi.musl.node'
-        test: false
+              - template: artifacts.yml
+                parameters:
+                  artifact_name: alpine-arm64-musl
+                  prebuild_folder_name: 'linux-arm64'
+                  output_node_file: 'node.napi.musl.node'
+                  test: false
 
-- job: publish
-  pool:
-    vmImage: 'ubuntu-latest'
-  condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq('${{ parameters.testGitHubRelease }}', 'true')))
-  dependsOn:
-  - win32_x64
-  - darwin_x64
-  - darwin_arm64
-  - Linux_x64_glibc_Node_18_x
-  - Linux_arm64_glibc_Node_18_x
-  - Linux_armhf_glibc_Node_18_x
-  - alpine_x64_musl
-  - alpine_arm64_musl
-  steps:
-    - template: publish.yml
-      parameters:
-        testGitHubRelease: ${{ parameters.testGitHubRelease }}
+      - stage: publish
+        dependsOn: Build
+        pool:
+          vmImage: '1es-ubuntu-22.04-x64'
+          os: linux
+        condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq('${{ parameters.testGitHubRelease }}', 'true')))
+        steps:
+          - template: publish.yml
+            parameters:
+              testGitHubRelease: ${{ parameters.testGitHubRelease }}

--- a/build/main.yml
+++ b/build/main.yml
@@ -214,7 +214,9 @@ extends:
           vmImage: '1es-ubuntu-22.04-x64'
           os: linux
         condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq('${{ parameters.testGitHubRelease }}', 'true')))
-        steps:
-          - template: build/publish.yml@self
-            parameters:
-              testGitHubRelease: ${{ parameters.testGitHubRelease }}
+        jobs:
+          - job: win32_x64
+            steps:
+              - template: build/publish.yml@self
+                parameters:
+                  testGitHubRelease: ${{ parameters.testGitHubRelease }}

--- a/build/main.yml
+++ b/build/main.yml
@@ -36,7 +36,7 @@ extends:
               name: 1es-windows-2019-x64
               os: windows
             steps:
-              - template: build.yml
+              - template: build.yml@self
                 parameters:
                   artifact_name: 'win32-x64'
                   prebuild_folder_name: 'win32-x64'
@@ -47,7 +47,7 @@ extends:
               name: 1es-windows-2019-x64
               os: windows
             steps:
-              - template: build.yml
+              - template: build.yml@self
                 parameters:
                   ARCH: arm64
                   npm_config_arch: arm64
@@ -62,7 +62,7 @@ extends:
               vmImage: 'macOS-latest'
               os: macOS
             steps:
-              - template: build.yml
+              - template: build.yml@self
                 parameters:
                   ARCH: ''
                   artifact_name: 'darwin-x64'
@@ -74,7 +74,7 @@ extends:
               vmImage: 'macOS-latest'
               os: macOS
             steps:
-              - template: build.yml
+              - template: build.yml@self
                 parameters:
                   ARCH: arm64
                   artifact_name: 'darwin-arm64'
@@ -89,7 +89,7 @@ extends:
               testNodeVersion: '18.x'
               timeoutInMinutes: 30
               testSteps:
-                - template: build.yml
+                - template: build.yml@self
                   parameters:
                     ARCH: x64
                     artifact_name: 'linux-x64'
@@ -106,7 +106,7 @@ extends:
               timeoutInMinutes: 30
               targetArch: arm64
               testSteps:
-                - template: build.yml
+                - template: build.yml@self
                   parameters:
                     ARCH: arm64
                     npm_config_arch: arm64
@@ -126,7 +126,7 @@ extends:
               timeoutInMinutes: 30
               targetArch: armhf
               testSteps:
-                - template: build.yml
+                - template: build.yml@self
                   parameters:
                     ARCH: arm
                     npm_config_arch: arm
@@ -143,7 +143,7 @@ extends:
               vmImage: '1es-ubuntu-22.04-x64'
               os: linux
             steps:
-              - template: build.yml
+              - template: build.yml@self
                 parameters:
                   build: false
                   test: false
@@ -165,7 +165,7 @@ extends:
                       docker tag node:14.16.0-alpine builder
                       docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
-              - template: artifacts.yml
+              - template: artifacts.yml@self
                 parameters:
                   artifact_name: alpine-x64-musl
                   prebuild_folder_name: 'linux-x64'
@@ -178,7 +178,7 @@ extends:
               vmImage: '1es-ubuntu-22.04-x64'
               os: linux
             steps:
-              - template: build.yml
+              - template: build.yml@self
                 parameters:
                   build: false
                   test: false

--- a/build/main.yml
+++ b/build/main.yml
@@ -25,9 +25,9 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
-        sourceAnalysisPool: 1es-windows-2019-x64
-        tsa:
-          enabled: true
+      sourceAnalysisPool: 1es-windows-2019-x64
+      tsa:
+        enabled: true
     stages:
       - stage: Build
         jobs:

--- a/build/main.yml
+++ b/build/main.yml
@@ -59,6 +59,7 @@ extends:
 
           - job: darwin_x64
             pool:
+              name: Azure Pipelines
               vmImage: 'macOS-latest'
               os: macOS
             steps:
@@ -71,6 +72,7 @@ extends:
 
           - job: darwin_arm64
             pool:
+              name: Azure Pipelines
               vmImage: 'macOS-latest'
               os: macOS
             steps:
@@ -140,7 +142,7 @@ extends:
 
           - job: alpine_x64_musl
             pool:
-              vmImage: '1es-ubuntu-22.04-x64'
+              vmImage: '1es-ubuntu-20.04-x64'
               os: linux
             templateContext:
               outputs:
@@ -180,7 +182,7 @@ extends:
 
           - job: alpine_arm64_musl
             pool:
-              vmImage: '1es-ubuntu-22.04-x64'
+              vmImage: '1es-ubuntu-20.04-x64'
               os: linux
             templateContext:
               outputs:
@@ -221,7 +223,7 @@ extends:
       - stage: publish
         dependsOn: Build
         pool:
-          vmImage: '1es-ubuntu-22.04-x64'
+          vmImage: '1es-ubuntu-20.04-x64'
           os: linux
         condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq('${{ parameters.testGitHubRelease }}', 'true')))
         jobs:

--- a/build/main.yml
+++ b/build/main.yml
@@ -104,26 +104,28 @@ extends:
                   output_node_file: 'node.napi.glibc.node'
                   test: false
 
-          - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-            parameters:
-              templateContext:
-                outputs:
-                  - output: pipelineArtifact
-                    targetPath: $(Build.ArtifactStagingDirectory)
-                    artifactName: 'linux-x64'
-              jobDisplayName: linux_x64_glibc
-              jobPlatformName: Linux_x64_glibc
-              testNodeVersion: '18.x'
-              timeoutInMinutes: 30
-              testSteps:
-                - template: build/build.yml@self
-                  parameters:
-                    ARCH: x64
-                    artifact_name: 'linux-x64'
-                    prebuild_folder_name: 'linux-x64'
-                    yum_install_python: false
-                    install_node: false
-                    output_node_file: 'node.napi.glibc.node'
+          - job: linux_x64_glibc
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'linux-x64'
+            steps:
+              - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+                parameters:
+                  jobDisplayName: linux_x64_glibc
+                  jobPlatformName: Linux_x64_glibc
+                  testNodeVersion: '18.x'
+                  timeoutInMinutes: 30
+                  testSteps:
+                    - template: build/build.yml@self
+                      parameters:
+                        ARCH: x64
+                        artifact_name: 'linux-x64'
+                        prebuild_folder_name: 'linux-x64'
+                        yum_install_python: false
+                        install_node: false
+                        output_node_file: 'node.napi.glibc.node'
 
           - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
             parameters:

--- a/build/main.yml
+++ b/build/main.yml
@@ -111,71 +111,73 @@ extends:
                   targetPath: $(Build.ArtifactStagingDirectory)
                   artifactName: 'linux-x64'
             steps:
-              - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+              - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
                 parameters:
-                  jobDisplayName: linux_x64_glibc
-                  jobPlatformName: Linux_x64_glibc
                   testNodeVersion: '18.x'
-                  timeoutInMinutes: 30
-                  testSteps:
-                    - template: build/build.yml@self
-                      parameters:
-                        ARCH: x64
-                        artifact_name: 'linux-x64'
-                        prebuild_folder_name: 'linux-x64'
-                        yum_install_python: false
-                        install_node: false
-                        output_node_file: 'node.napi.glibc.node'
+                  targetArch: x64
+              - template: build/build.yml@self
+                parameters:
+                  ARCH: x64
+                  artifact_name: 'linux-x64'
+                  prebuild_folder_name: 'linux-x64'
+                  yum_install_python: false
+                  install_node: false
+                  output_node_file: 'node.napi.glibc.node'
+              - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
+                parameters:
+                  targetArch: x64
 
-          - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-            parameters:
-              templateContext:
-                outputs:
-                  - output: pipelineArtifact
-                    targetPath: $(Build.ArtifactStagingDirectory)
-                    artifactName: 'linux-arm64-glibc'
-              jobDisplayName: linux_arm64_glibc
-              jobPlatformName: Linux_arm64_glibc
-              testNodeVersion: '18.x'
-              timeoutInMinutes: 30
-              targetArch: arm64
-              testSteps:
-                - template: build/build.yml@self
-                  parameters:
-                    ARCH: arm64
-                    npm_config_arch: arm64
-                    ARCHIVE_SUFFIX: -armv8
-                    artifact_name: 'linux-arm64-glibc'
-                    prebuild_folder_name: 'linux-arm64'
-                    yum_install_python: false
-                    test: false
-                    install_node: false
-                    output_node_file: 'node.napi.glibc.node'
+          - job: linux_arm64_glibc
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'linux-arm64-glibc'
+            steps:
+              - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
+                parameters:
+                  testNodeVersion: '18.x'
+                  targetArch: arm64
+              - template: build/build.yml@self
+                parameters:
+                  ARCH: arm64
+                  npm_config_arch: arm64
+                  ARCHIVE_SUFFIX: -armv8
+                  artifact_name: 'linux-arm64-glibc'
+                  prebuild_folder_name: 'linux-arm64'
+                  yum_install_python: false
+                  test: false
+                  install_node: false
+                  output_node_file: 'node.napi.glibc.node'
+              - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
+                parameters:
+                  targetArch: arm64
 
-          - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-            parameters:
-              templateContext:
-                outputs:
-                  - output: pipelineArtifact
-                    targetPath: $(Build.ArtifactStagingDirectory)
-                    artifactName: 'linux-armhf-glibc'
-              jobDisplayName: linux_armhf_glibc
-              jobPlatformName: Linux_armhf_glibc
-              testNodeVersion: '18.x'
-              timeoutInMinutes: 30
-              targetArch: armhf
-              testSteps:
-                - template: build/build.yml@self
-                  parameters:
-                    ARCH: arm
-                    npm_config_arch: arm
-                    ARCHIVE_SUFFIX: -armv7
-                    artifact_name: 'linux-armhf-glibc'
-                    prebuild_folder_name: 'linux-arm'
-                    yum_install_python: false
-                    test: false
-                    install_node: false
-                    output_node_file: 'node.napi.glibc.node'
+          - job: linux_armhf_glibc
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'linux-armhf-glibc'
+            steps:
+              - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
+                parameters:
+                  testNodeVersion: '18.x'
+                  targetArch: armhf
+              - template: build/build.yml@self
+                parameters:
+                  ARCH: arm
+                  npm_config_arch: arm
+                  ARCHIVE_SUFFIX: -armv7
+                  artifact_name: 'linux-armhf-glibc'
+                  prebuild_folder_name: 'linux-arm'
+                  yum_install_python: false
+                  test: false
+                  install_node: false
+                  output_node_file: 'node.napi.glibc.node'
+              - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
+                parameters:
+                  targetArch: armhf
 
           - job: alpine_x64_musl
             pool:

--- a/build/main.yml
+++ b/build/main.yml
@@ -105,12 +105,12 @@ extends:
                   test: false
 
           - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-            templateContext:
-              outputs:
-                - output: pipelineArtifact
-                  targetPath: $(Build.ArtifactStagingDirectory)
-                  artifactName: 'linux-x64'
             parameters:
+              templateContext:
+                outputs:
+                  - output: pipelineArtifact
+                    targetPath: $(Build.ArtifactStagingDirectory)
+                    artifactName: 'linux-x64'
               jobDisplayName: linux_x64_glibc
               jobPlatformName: Linux_x64_glibc
               testNodeVersion: '18.x'
@@ -126,12 +126,12 @@ extends:
                     output_node_file: 'node.napi.glibc.node'
 
           - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-            templateContext:
-              outputs:
-                - output: pipelineArtifact
-                  targetPath: $(Build.ArtifactStagingDirectory)
-                  artifactName: 'linux-arm64-glibc'
             parameters:
+              templateContext:
+                outputs:
+                  - output: pipelineArtifact
+                    targetPath: $(Build.ArtifactStagingDirectory)
+                    artifactName: 'linux-arm64-glibc'
               jobDisplayName: linux_arm64_glibc
               jobPlatformName: Linux_arm64_glibc
               testNodeVersion: '18.x'
@@ -151,12 +151,12 @@ extends:
                     output_node_file: 'node.napi.glibc.node'
 
           - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
-            templateContext:
-              outputs:
-                - output: pipelineArtifact
-                  targetPath: $(Build.ArtifactStagingDirectory)
-                  artifactName: 'linux-armhf-glibc'
             parameters:
+              templateContext:
+                outputs:
+                  - output: pipelineArtifact
+                    targetPath: $(Build.ArtifactStagingDirectory)
+                    artifactName: 'linux-armhf-glibc'
               jobDisplayName: linux_armhf_glibc
               jobPlatformName: Linux_armhf_glibc
               testNodeVersion: '18.x'

--- a/build/main.yml
+++ b/build/main.yml
@@ -35,6 +35,8 @@ extends:
             pool:
               name: 1es-windows-2019-x64
               os: windows
+            variables:
+              - group: 'API Scan'
             templateContext:
               outputs:
                 - output: pipelineArtifact
@@ -51,6 +53,8 @@ extends:
             pool:
               name: 1es-windows-2019-x64
               os: windows
+            variables:
+              - group: 'API Scan'
             templateContext:
               outputs:
                 - output: pipelineArtifact

--- a/build/main.yml
+++ b/build/main.yml
@@ -36,7 +36,7 @@ extends:
               name: 1es-windows-2019-x64
               os: windows
             steps:
-              - template: build.yml@self
+              - template: build/build.yml@self
                 parameters:
                   artifact_name: 'win32-x64'
                   prebuild_folder_name: 'win32-x64'
@@ -47,7 +47,7 @@ extends:
               name: 1es-windows-2019-x64
               os: windows
             steps:
-              - template: build.yml@self
+              - template: build/build.yml@self
                 parameters:
                   ARCH: arm64
                   npm_config_arch: arm64
@@ -62,7 +62,7 @@ extends:
               vmImage: 'macOS-latest'
               os: macOS
             steps:
-              - template: build.yml@self
+              - template: build/build.yml@self
                 parameters:
                   ARCH: ''
                   artifact_name: 'darwin-x64'
@@ -74,7 +74,7 @@ extends:
               vmImage: 'macOS-latest'
               os: macOS
             steps:
-              - template: build.yml@self
+              - template: build/build.yml@self
                 parameters:
                   ARCH: arm64
                   artifact_name: 'darwin-arm64'
@@ -89,7 +89,7 @@ extends:
               testNodeVersion: '18.x'
               timeoutInMinutes: 30
               testSteps:
-                - template: build.yml@self
+                - template: build/build.yml@self
                   parameters:
                     ARCH: x64
                     artifact_name: 'linux-x64'
@@ -106,7 +106,7 @@ extends:
               timeoutInMinutes: 30
               targetArch: arm64
               testSteps:
-                - template: build.yml@self
+                - template: build/build.yml@self
                   parameters:
                     ARCH: arm64
                     npm_config_arch: arm64
@@ -126,7 +126,7 @@ extends:
               timeoutInMinutes: 30
               targetArch: armhf
               testSteps:
-                - template: build.yml@self
+                - template: build/build.yml@self
                   parameters:
                     ARCH: arm
                     npm_config_arch: arm
@@ -143,7 +143,7 @@ extends:
               vmImage: '1es-ubuntu-22.04-x64'
               os: linux
             steps:
-              - template: build.yml@self
+              - template: build/build.yml@self
                 parameters:
                   build: false
                   test: false
@@ -165,7 +165,7 @@ extends:
                       docker tag node:14.16.0-alpine builder
                       docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
-              - template: artifacts.yml@self
+              - template: build/artifacts.yml@self
                 parameters:
                   artifact_name: alpine-x64-musl
                   prebuild_folder_name: 'linux-x64'
@@ -178,7 +178,7 @@ extends:
               vmImage: '1es-ubuntu-22.04-x64'
               os: linux
             steps:
-              - template: build.yml@self
+              - template: build/build.yml@self
                 parameters:
                   build: false
                   test: false
@@ -201,7 +201,7 @@ extends:
                       docker tag arm64v8/node:14.16.0-alpine builder
                       docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
-              - template: artifacts.yml
+              - template: build/artifacts.yml@self
                 parameters:
                   artifact_name: alpine-arm64-musl
                   prebuild_folder_name: 'linux-arm64'
@@ -215,6 +215,6 @@ extends:
           os: linux
         condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq('${{ parameters.testGitHubRelease }}', 'true')))
         steps:
-          - template: publish.yml
+          - template: build/publish.yml@self
             parameters:
               testGitHubRelease: ${{ parameters.testGitHubRelease }}

--- a/build/main.yml
+++ b/build/main.yml
@@ -142,6 +142,11 @@ extends:
             pool:
               vmImage: '1es-ubuntu-22.04-x64'
               os: linux
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: alpine-x64-musl
             steps:
               - template: build/build.yml@self
                 parameters:
@@ -177,6 +182,11 @@ extends:
             pool:
               vmImage: '1es-ubuntu-22.04-x64'
               os: linux
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: alpine-arm64-musl
             steps:
               - template: build/build.yml@self
                 parameters:

--- a/build/main.yml
+++ b/build/main.yml
@@ -113,8 +113,8 @@ extends:
             steps:
               - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
                 parameters:
-                  testNodeVersion: '18.x'
-                  targetArch: x64
+                  arch: x64
+                  nodeVersion: '18.x'
               - template: build/build.yml@self
                 parameters:
                   ARCH: x64
@@ -125,7 +125,7 @@ extends:
                   output_node_file: 'node.napi.glibc.node'
               - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
                 parameters:
-                  targetArch: x64
+                  arch: x64
 
           - job: linux_arm64_glibc
             templateContext:
@@ -136,8 +136,8 @@ extends:
             steps:
               - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
                 parameters:
-                  testNodeVersion: '18.x'
-                  targetArch: arm64
+                  arch: arm64
+                  nodeVersion: '18.x'
               - template: build/build.yml@self
                 parameters:
                   ARCH: arm64
@@ -151,7 +151,7 @@ extends:
                   output_node_file: 'node.napi.glibc.node'
               - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
                 parameters:
-                  targetArch: arm64
+                  arch: arm64
 
           - job: linux_armhf_glibc
             templateContext:
@@ -162,8 +162,8 @@ extends:
             steps:
               - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
                 parameters:
-                  testNodeVersion: '18.x'
-                  targetArch: armhf
+                  arch: armhf
+                  nodeVersion: '18.x'
               - template: build/build.yml@self
                 parameters:
                   ARCH: arm
@@ -177,7 +177,7 @@ extends:
                   output_node_file: 'node.napi.glibc.node'
               - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
                 parameters:
-                  targetArch: armhf
+                  arch: armhf
 
           - job: alpine_x64_musl
             pool:

--- a/build/main.yml
+++ b/build/main.yml
@@ -105,6 +105,9 @@ extends:
                   test: false
 
           - job: linux_x64_glibc
+            pool:
+              name: '1es-ubuntu-22.04-x64'
+              os: linux
             templateContext:
               outputs:
                 - output: pipelineArtifact
@@ -128,6 +131,9 @@ extends:
                   arch: x64
 
           - job: linux_arm64_glibc
+            pool:
+              name: '1es-ubuntu-22.04-x64'
+              os: linux
             templateContext:
               outputs:
                 - output: pipelineArtifact
@@ -154,6 +160,9 @@ extends:
                   arch: arm64
 
           - job: linux_armhf_glibc
+            pool:
+              name: '1es-ubuntu-22.04-x64'
+              os: linux
             templateContext:
               outputs:
                 - output: pipelineArtifact

--- a/build/main.yml
+++ b/build/main.yml
@@ -35,6 +35,11 @@ extends:
             pool:
               name: 1es-windows-2019-x64
               os: windows
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'win32-x64'
             steps:
               - template: build/build.yml@self
                 parameters:
@@ -46,6 +51,11 @@ extends:
             pool:
               name: 1es-windows-2019-x64
               os: windows
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'win32-arm64'
             steps:
               - template: build/build.yml@self
                 parameters:
@@ -62,6 +72,11 @@ extends:
               name: Azure Pipelines
               vmImage: 'macOS-latest'
               os: macOS
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'darwin-x64'
             steps:
               - template: build/build.yml@self
                 parameters:
@@ -75,6 +90,11 @@ extends:
               name: Azure Pipelines
               vmImage: 'macOS-latest'
               os: macOS
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'darwin-arm64'
             steps:
               - template: build/build.yml@self
                 parameters:
@@ -85,6 +105,11 @@ extends:
                   test: false
 
           - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'linux-x64'
             parameters:
               jobDisplayName: linux_x64_glibc
               jobPlatformName: Linux_x64_glibc
@@ -101,6 +126,11 @@ extends:
                     output_node_file: 'node.napi.glibc.node'
 
           - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'linux-arm64-glibc'
             parameters:
               jobDisplayName: linux_arm64_glibc
               jobPlatformName: Linux_arm64_glibc
@@ -113,7 +143,7 @@ extends:
                     ARCH: arm64
                     npm_config_arch: arm64
                     ARCHIVE_SUFFIX: -armv8
-                    artifact_name: linux-arm64-glibc
+                    artifact_name: 'linux-arm64-glibc'
                     prebuild_folder_name: 'linux-arm64'
                     yum_install_python: false
                     test: false
@@ -121,6 +151,11 @@ extends:
                     output_node_file: 'node.napi.glibc.node'
 
           - template: azure-pipelines/npm-package/templates/jobs/compile.yml@templates
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: 'linux-armhf-glibc'
             parameters:
               jobDisplayName: linux_armhf_glibc
               jobPlatformName: Linux_armhf_glibc
@@ -133,7 +168,7 @@ extends:
                     ARCH: arm
                     npm_config_arch: arm
                     ARCHIVE_SUFFIX: -armv7
-                    artifact_name: linux-armhf-glibc
+                    artifact_name: 'linux-armhf-glibc'
                     prebuild_folder_name: 'linux-arm'
                     yum_install_python: false
                     test: false
@@ -142,7 +177,7 @@ extends:
 
           - job: alpine_x64_musl
             pool:
-              vmImage: '1es-ubuntu-20.04-x64'
+              name: '1es-ubuntu-22.04-x64'
               os: linux
             templateContext:
               outputs:
@@ -182,7 +217,7 @@ extends:
 
           - job: alpine_arm64_musl
             pool:
-              vmImage: '1es-ubuntu-20.04-x64'
+              name: '1es-ubuntu-22.04-x64'
               os: linux
             templateContext:
               outputs:
@@ -223,7 +258,7 @@ extends:
       - stage: publish
         dependsOn: Build
         pool:
-          vmImage: '1es-ubuntu-20.04-x64'
+          name: '1es-ubuntu-22.04-x64'
           os: linux
         condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq('${{ parameters.testGitHubRelease }}', 'true')))
         jobs:

--- a/build/main.yml
+++ b/build/main.yml
@@ -53,8 +53,6 @@ extends:
             pool:
               name: 1es-windows-2019-x64
               os: windows
-            variables:
-              - group: 'API Scan'
             templateContext:
               outputs:
                 - output: pipelineArtifact


### PR DESCRIPTION
Migrates the pipeline to use the 1ES Pipeline Template
It also inlines the APIScan tasks to run for the Windows x64 job.