### PR TITLE
chore: update zeromq.js@6.0.0-beta.19

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -83,7 +83,8 @@ steps:
 
 - bash: |
     export PREBUILD_STRIP_BIN=$STRIP
-    npm install
+    npm install -g pnpm@latest-8
+    pnpm install
     npm run prebuild
   displayName: Build
   condition: and(succeeded(), eq('${{ parameters.build }}', 'true'), ne('${{ parameters.ARCH }}', ''))
@@ -94,7 +95,8 @@ steps:
     PREBUILD_ARCH: ${{ parameters.ARCH }}
 
 - bash: |
-    npm install
+    npm install -g pnpm@latest-8
+    pnpm install
     npm run prebuild
   displayName: Build
   condition: and(succeeded(), eq('${{ parameters.build }}', 'true'), eq('${{ parameters.ARCH }}', ''))

--- a/build/main.yml
+++ b/build/main.yml
@@ -63,7 +63,6 @@ extends:
                 parameters:
                   ARCH: arm64
                   npm_config_arch: arm64
-                  node_version: '20.x'
                   artifact_name: 'win32-arm64'
                   prebuild_folder_name: 'win32-arm64'
                   output_node_file: 'node.napi.glibc.node'

--- a/build/main.yml
+++ b/build/main.yml
@@ -63,7 +63,7 @@ extends:
                 parameters:
                   ARCH: arm64
                   npm_config_arch: arm64
-                  node_version: '19.x'
+                  node_version: '20.x'
                   artifact_name: 'win32-arm64'
                   prebuild_folder_name: 'win32-arm64'
                   output_node_file: 'node.napi.glibc.node'
@@ -119,7 +119,7 @@ extends:
               - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
                 parameters:
                   arch: x64
-                  nodeVersion: '18.x'
+                  nodeVersion: '20.x'
               - template: build/build.yml@self
                 parameters:
                   ARCH: x64
@@ -145,7 +145,7 @@ extends:
               - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
                 parameters:
                   arch: arm64
-                  nodeVersion: '18.x'
+                  nodeVersion: '20.x'
               - template: build/build.yml@self
                 parameters:
                   ARCH: arm64
@@ -174,7 +174,7 @@ extends:
               - template: azure-pipelines/common/steps/setup-linux-toolchains.yml@templates
                 parameters:
                   arch: armhf
-                  nodeVersion: '18.x'
+                  nodeVersion: '20.x'
               - template: build/build.yml@self
                 parameters:
                   ARCH: arm

--- a/build/main.yml
+++ b/build/main.yml
@@ -212,7 +212,7 @@ extends:
                 displayName: Build
                 env:
                   CURRENDIR: $(Build.SourcesDirectory)
-                  DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm install && npm run prebuild
+                  DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g pnpm@latest-8 && pnpm install && npm run prebuild
                 inputs:
                   targetType: 'inline'
                   workingDirectory: zeromq.js
@@ -252,7 +252,7 @@ extends:
                 displayName: Build
                 env:
                   CURRENDIR: $(Build.SourcesDirectory)
-                  DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g cross-env && cross-env ARCH=arm64 npm_config_arch=arm64 npm install && cross-env ARCH=arm64 npm_config_arch=arm64 npm run prebuild
+                  DOCKERCMD: apk add --no-cache pkgconfig curl tar python3 make gcc g++ cmake musl-dev && npm i -g cross-env pnpm@latest-8 && cross-env ARCH=arm64 npm_config_arch=arm64 pnpm install && cross-env ARCH=arm64 npm_config_arch=arm64 npm run prebuild
                 inputs:
                   targetType: 'inline'
                   workingDirectory: zeromq.js

--- a/build/main.yml
+++ b/build/main.yml
@@ -63,6 +63,7 @@ extends:
                 parameters:
                   ARCH: arm64
                   npm_config_arch: arm64
+                  node_version: '20.x'
                   artifact_name: 'win32-arm64'
                   prebuild_folder_name: 'win32-arm64'
                   output_node_file: 'node.napi.glibc.node'

--- a/build/main.yml
+++ b/build/main.yml
@@ -217,8 +217,8 @@ extends:
                   targetType: 'inline'
                   workingDirectory: zeromq.js
                   script: |
-                      docker pull node:14.16.0-alpine
-                      docker tag node:14.16.0-alpine builder
+                      docker pull node:18.20.3-alpine3.18
+                      docker tag node:18.20.3-alpine3.18 builder
                       docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
               - template: build/artifacts.yml@self
@@ -258,8 +258,8 @@ extends:
                   workingDirectory: zeromq.js
                   script: |
                       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                      docker pull arm64v8/node:14.16.0-alpine
-                      docker tag arm64v8/node:14.16.0-alpine builder
+                      docker pull --platform linux/arm64/v8 node:18.20.3-alpine3.18
+                      docker tag node:18.20.3-alpine3.18 builder
                       docker run --volume $CURRENDIR/zeromq.js:/app --workdir /app --privileged builder sh -c "$DOCKERCMD"
 
               - template: build/artifacts.yml@self

--- a/build/main.yml
+++ b/build/main.yml
@@ -207,7 +207,7 @@ extends:
 
               - task: DockerInstaller@0
                 inputs:
-                  dockerVersion: '17.09.0-ce'
+                  dockerVersion: '24.0.9'
 
               - task: Bash@3
                 displayName: Build
@@ -247,7 +247,7 @@ extends:
 
               - task: DockerInstaller@0
                 inputs:
-                  dockerVersion: '17.09.0-ce'
+                  dockerVersion: '24.0.9'
 
               - task: Bash@3
                 displayName: Build

--- a/build/main.yml
+++ b/build/main.yml
@@ -47,7 +47,7 @@ extends:
                 parameters:
                   artifact_name: 'win32-x64'
                   prebuild_folder_name: 'win32-x64'
-                  output_node_file: 'node.napi.glibc.node'
+                  output_node_file: 'zeromq.glibc.node'
 
           - job: win32_arm64
             pool:
@@ -66,7 +66,7 @@ extends:
                   node_version: '20.x'
                   artifact_name: 'win32-arm64'
                   prebuild_folder_name: 'win32-arm64'
-                  output_node_file: 'node.napi.glibc.node'
+                  output_node_file: 'zeromq.glibc.node'
                   test: false
 
           - job: darwin_x64
@@ -85,7 +85,7 @@ extends:
                   ARCH: ''
                   artifact_name: 'darwin-x64'
                   prebuild_folder_name: 'darwin-x64'
-                  output_node_file: 'node.napi.glibc.node'
+                  output_node_file: 'zeromq.glibc.node'
 
           - job: darwin_arm64
             pool:
@@ -103,7 +103,7 @@ extends:
                   ARCH: arm64
                   artifact_name: 'darwin-arm64'
                   prebuild_folder_name: 'darwin-arm64'
-                  output_node_file: 'node.napi.glibc.node'
+                  output_node_file: 'zeromq.glibc.node'
                   test: false
 
           - job: linux_x64_glibc
@@ -127,7 +127,7 @@ extends:
                   prebuild_folder_name: 'linux-x64'
                   yum_install_python: false
                   install_node: false
-                  output_node_file: 'node.napi.glibc.node'
+                  output_node_file: 'zeromq.glibc.node'
               - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
                 parameters:
                   arch: x64
@@ -156,7 +156,7 @@ extends:
                   yum_install_python: false
                   test: false
                   install_node: false
-                  output_node_file: 'node.napi.glibc.node'
+                  output_node_file: 'zeromq.glibc.node'
               - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
                 parameters:
                   arch: arm64
@@ -185,7 +185,7 @@ extends:
                   yum_install_python: false
                   test: false
                   install_node: false
-                  output_node_file: 'node.napi.glibc.node'
+                  output_node_file: 'zeromq.glibc.node'
               - template: azure-pipelines/common/steps/verify-platform-requirements.yml@templates
                 parameters:
                   arch: armhf
@@ -226,7 +226,7 @@ extends:
                 parameters:
                   artifact_name: alpine-x64-musl
                   prebuild_folder_name: 'linux-x64'
-                  output_node_file: 'node.napi.musl.node'
+                  output_node_file: 'zeromq.musl.node'
                   test: false
 
 
@@ -267,7 +267,7 @@ extends:
                 parameters:
                   artifact_name: alpine-arm64-musl
                   prebuild_folder_name: 'linux-arm64'
-                  output_node_file: 'node.napi.musl.node'
+                  output_node_file: 'zeromq.musl.node'
                   test: false
 
       - stage: publish

--- a/build/patch.patch
+++ b/build/patch.patch
@@ -1,5 +1,5 @@
 diff --git a/package.json b/package.json
-index c9611cf..ed8f03a 100644
+index c9611cf..0441bb3 100644
 --- a/package.json
 +++ b/package.json
 @@ -18,7 +18,7 @@
@@ -19,6 +19,15 @@ index c9611cf..ed8f03a 100644
      "downlevel-dts": "^0.11.0",
      "electron-mocha": "^11.0.2",
      "eslint-config-atomic": "^1.18.1",
+@@ -46,7 +45,7 @@
+     "mocha": "^10.1.0",
+     "node-gyp": "^10.0.1",
+     "npm-run-all2": "^6.0.4",
+-    "prebuildify": "^5.0.1",
++    "prebuildify": "^6.0.1",
+     "prettier": "^2.8.0",
+     "rocha": "^2.5.10",
+     "semver": "^7.3.8",
 @@ -59,7 +58,9 @@
    "pnpm": {
      "overrides": {
@@ -40,7 +49,7 @@ index c9611cf..ed8f03a 100644
      "clean.temp": "shx rm -rf ./tmp && shx mkdir -p ./tmp && shx touch ./tmp/.gitkeep",
      "build.library.compat": "shx rm -rf ./lib/ts3.7 && downlevel-dts ./lib ./lib/ts3.7 --to=3.7",
 diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index 1acd1f1..91951cd 100644
+index 1acd1f1..db6ddfb 100644
 --- a/pnpm-lock.yaml
 +++ b/pnpm-lock.yaml
 @@ -7,17 +7,19 @@ settings:
@@ -76,6 +85,17 @@ index 1acd1f1..91951cd 100644
    downlevel-dts:
      specifier: ^0.11.0
      version: 0.11.0
+@@ -90,8 +89,8 @@ devDependencies:
+     specifier: ^6.0.4
+     version: 6.0.4
+   prebuildify:
+-    specifier: ^5.0.1
+-    version: 5.0.1
++    specifier: ^6.0.1
++    version: 6.0.1
+   prettier:
+     specifier: ^2.8.0
+     version: 2.8.0
 @@ -124,11 +123,6 @@ packages:
      engines: {node: '>=6'}
      dev: true
@@ -390,7 +410,20 @@ index 1acd1f1..91951cd 100644
        eslint: 7.32.0
        eslint-plugin-react-native-globals: 0.1.2
      transitivePeerDependencies:
-@@ -2651,10 +2729,6 @@ packages:
+@@ -2592,12 +2670,6 @@ packages:
+       strip-eof: 1.0.0
+     dev: true
+ 
+-  /execspawn@1.0.1:
+-    resolution: {integrity: sha512-s2k06Jy9i8CUkYe0+DxRlvtkZoOkwwfhB+Xxo5HGUtrISVW2m98jO2tr67DGRFxZwkjQqloA3v/tNtjhBRBieg==}
+-    dependencies:
+-      util-extend: 1.0.3
+-    dev: true
+-
+   /exit@0.1.2:
+     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+     engines: {node: '>= 0.8.0'}
+@@ -2651,10 +2723,6 @@ packages:
        flat-cache: 3.0.4
      dev: true
  
@@ -401,7 +434,7 @@ index 1acd1f1..91951cd 100644
    /filename-reserved-regex@2.0.0:
      resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
      engines: {node: '>=4'}
-@@ -3998,10 +4072,6 @@ packages:
+@@ -3998,10 +4066,6 @@ packages:
        semver: 7.3.8
      dev: true
  
@@ -412,7 +445,7 @@ index 1acd1f1..91951cd 100644
    /node-addon-api@3.2.1:
      resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
      dev: true
-@@ -4010,10 +4080,9 @@ packages:
+@@ -4010,10 +4074,9 @@ packages:
      resolution: {integrity: sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==}
      dev: false
  
@@ -425,7 +458,21 @@ index 1acd1f1..91951cd 100644
  
    /node-gyp@10.0.1:
      resolution: {integrity: sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==}
-@@ -4917,6 +4986,7 @@ packages:
+@@ -4655,11 +4718,10 @@ packages:
+       source-map-js: 1.0.2
+     dev: true
+ 
+-  /prebuildify@5.0.1:
+-    resolution: {integrity: sha512-vXpKLfIEsDCqMJWVIoSrUUBJQIuAk9uHAkLiGJuTdXdqKSJ10sHmWeuNCDkIoRFTV1BDGYMghHVmDFP8NfkA2Q==}
++  /prebuildify@6.0.1:
++    resolution: {integrity: sha512-8Y2oOOateom/s8dNBsGIcnm6AxPmLH4/nanQzL5lQMU+sC0CMhzARZHizwr36pUPLdvBnOkCNQzxg4djuFSgIw==}
+     hasBin: true
+     dependencies:
+-      execspawn: 1.0.1
+       minimist: 1.2.7
+       mkdirp-classic: 0.5.3
+       node-abi: 3.28.0
+@@ -4917,6 +4979,7 @@ packages:
  
    /rimraf@3.0.2:
      resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -433,7 +480,18 @@ index 1acd1f1..91951cd 100644
      hasBin: true
      dependencies:
        glob: 7.2.3
-@@ -5748,7 +5818,7 @@ packages:
+@@ -5690,10 +5753,6 @@ packages:
+     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+     dev: true
+ 
+-  /util-extend@1.0.3:
+-    resolution: {integrity: sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==}
+-    dev: true
+-
+   /v8-compile-cache-lib@3.0.1:
+     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+     dev: true
+@@ -5748,7 +5807,7 @@ packages:
      requiresBuild: true
      dependencies:
        node-addon-api: 3.2.1

--- a/build/patch.patch
+++ b/build/patch.patch
@@ -1,108 +1,63 @@
-diff --git a/binding.gyp b/binding.gyp
-index 68a8f58..280b468 100644
---- a/binding.gyp
-+++ b/binding.gyp
-@@ -82,7 +82,6 @@
-             ['OS == "mac"', {
-               'libraries': [
-                 '<(module_root_dir)/build/libzmq/lib/libzmq.a',
--                "<!@(pkg-config libsodium --libs)",
-               ],
-             }],
- 
 diff --git a/package.json b/package.json
-index 058ecd1..cfd4a29 100644
+index c9611cf..ae00b2d 100644
 --- a/package.json
 +++ b/package.json
-@@ -20,11 +20,12 @@
-   "dependencies": {
-     "@aminya/node-gyp-build": "4.5.0-aminya.4",
-     "cross-env": "^7.0.3",
--    "node-addon-api": "^5.0.0",
-+    "node-addon-api": "^6.0.0",
-     "shelljs": "^0.8.5",
-     "shx": "^0.3.4"
-   },
-   "devDependencies": {
-+    "@babel/traverse": "7.23.2",
-     "@types/chai": "^4.3.4",
-     "@types/fs-extra": "^9.0.13",
-     "@types/mocha": "^10.0.0",
-@@ -35,7 +36,6 @@
+@@ -35,7 +35,6 @@
      "@types/which": "^2.0.1",
      "benchmark": "^2.1.4",
      "chai": "^4.3.7",
--    "deasync": "^0.1.28",
+-    "deasync": "^0.1.29",
      "downlevel-dts": "^0.11.0",
      "electron-mocha": "^11.0.2",
      "eslint-config-atomic": "^1.18.1",
+@@ -59,7 +58,8 @@
+   "pnpm": {
+     "overrides": {
+       "typescript": "~4.9.3",
+-      "node-gyp": "10.0.1"
++      "node-gyp": "10.0.1",
++      "@babel/traverse": "7.23.2"
+     }
+   },
+   "engines": {
 diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index 57780fc..5b67df3 100644
+index 1acd1f1..e767a08 100644
 --- a/pnpm-lock.yaml
 +++ b/pnpm-lock.yaml
-@@ -5,6 +5,7 @@ overrides:
- 
- specifiers:
-   '@aminya/node-gyp-build': 4.5.0-aminya.4
+@@ -7,6 +7,7 @@ settings:
+ overrides:
+   typescript: ~4.9.3
+   node-gyp: 10.0.1
 +  '@babel/traverse': 7.23.2
-   '@types/chai': ^4.3.4
-   '@types/fs-extra': ^9.0.13
-   '@types/mocha': ^10.0.0
-@@ -16,7 +17,6 @@ specifiers:
-   benchmark: ^2.1.4
-   chai: ^4.3.7
-   cross-env: ^7.0.3
--  deasync: ^0.1.28
-   downlevel-dts: ^0.11.0
-   electron-mocha: ^11.0.2
-   eslint-config-atomic: ^1.18.1
-@@ -25,7 +25,7 @@ specifiers:
-   gh-pages: ^4.0.0
-   minify-all-cli: ^1.0.13
-   mocha: ^10.1.0
--  node-addon-api: ^5.0.0
-+  node-addon-api: ^6.0.0
-   node-gyp: ^9.3.0
-   npm-run-all2: ^6.0.4
-   prebuildify: ^5.0.1
-@@ -43,11 +43,12 @@ specifiers:
+ 
  dependencies:
-   '@aminya/node-gyp-build': 4.5.0-aminya.4
-   cross-env: 7.0.3
--  node-addon-api: 5.0.0
-+  node-addon-api: 6.1.0
-   shelljs: 0.8.5
-   shx: 0.3.4
- 
- devDependencies:
-+  '@babel/traverse': 7.23.2
-   '@types/chai': 4.3.4
-   '@types/fs-extra': 9.0.13
-   '@types/mocha': 10.0.0
-@@ -58,7 +59,6 @@ devDependencies:
-   '@types/which': 2.0.1
-   benchmark: 2.1.4
-   chai: 4.3.7
--  deasync: 0.1.28
-   downlevel-dts: 0.11.0
-   electron-mocha: 11.0.2
-   eslint-config-atomic: 1.18.1
-@@ -106,6 +106,14 @@ packages:
+   '@aminya/node-gyp-build':
+@@ -56,9 +57,6 @@ devDependencies:
+   chai:
+     specifier: ^4.3.7
+     version: 4.3.7
+-  deasync:
+-    specifier: ^0.1.29
+-    version: 0.1.29
+   downlevel-dts:
+     specifier: ^0.11.0
+     version: 0.11.0
+@@ -150,6 +148,14 @@ packages:
        '@babel/highlight': 7.18.6
      dev: true
  
-+  /@babel/code-frame/7.22.13:
-+    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
++  /@babel/code-frame@7.24.7:
++    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
 +    engines: {node: '>=6.9.0'}
 +    dependencies:
-+      '@babel/highlight': 7.22.20
-+      chalk: 2.4.2
++      '@babel/highlight': 7.24.7
++      picocolors: 1.0.0
 +    dev: true
 +
-   /@babel/compat-data/7.20.1:
+   /@babel/compat-data@7.20.1:
      resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
      engines: {node: '>=6.9.0'}
-@@ -123,7 +131,7 @@ packages:
+@@ -167,7 +173,7 @@ packages:
        '@babel/helpers': 7.20.1
        '@babel/parser': 7.20.3
        '@babel/template': 7.18.10
@@ -110,57 +65,59 @@ index 57780fc..5b67df3 100644
 +      '@babel/traverse': 7.23.2
        '@babel/types': 7.20.2
        convert-source-map: 1.9.0
-       debug: 4.3.4
-@@ -157,6 +165,16 @@ packages:
+       debug: 4.3.4(supports-color@8.1.1)
+@@ -201,6 +207,16 @@ packages:
        jsesc: 2.5.2
      dev: true
  
-+  /@babel/generator/7.23.0:
-+    resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
++  /@babel/generator@7.24.7:
++    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
 +    engines: {node: '>=6.9.0'}
 +    dependencies:
-+      '@babel/types': 7.23.0
-+      '@jridgewell/gen-mapping': 0.3.2
-+      '@jridgewell/trace-mapping': 0.3.17
++      '@babel/types': 7.24.7
++      '@jridgewell/gen-mapping': 0.3.5
++      '@jridgewell/trace-mapping': 0.3.25
 +      jsesc: 2.5.2
 +    dev: true
 +
-   /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.2:
+   /@babel/helper-compilation-targets@7.20.0(@babel/core@7.20.2):
      resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
      engines: {node: '>=6.9.0'}
-@@ -175,19 +193,24 @@ packages:
+@@ -219,19 +235,26 @@ packages:
      engines: {node: '>=6.9.0'}
      dev: true
  
--  /@babel/helper-function-name/7.19.0:
+-  /@babel/helper-function-name@7.19.0:
 -    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
-+  /@babel/helper-environment-visitor/7.22.20:
-+    resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
-+    engines: {node: '>=6.9.0'}
-+    dev: true
-+
-+  /@babel/helper-function-name/7.23.0:
-+    resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
++  /@babel/helper-environment-visitor@7.24.7:
++    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
      engines: {node: '>=6.9.0'}
      dependencies:
 -      '@babel/template': 7.18.10
 -      '@babel/types': 7.20.2
-+      '@babel/template': 7.22.15
-+      '@babel/types': 7.23.0
++      '@babel/types': 7.24.7
      dev: true
  
--  /@babel/helper-hoist-variables/7.18.6:
+-  /@babel/helper-hoist-variables@7.18.6:
 -    resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
-+  /@babel/helper-hoist-variables/7.22.5:
-+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
++  /@babel/helper-function-name@7.24.7:
++    resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
      engines: {node: '>=6.9.0'}
      dependencies:
 -      '@babel/types': 7.20.2
-+      '@babel/types': 7.23.0
++      '@babel/template': 7.24.7
++      '@babel/types': 7.24.7
++    dev: true
++
++  /@babel/helper-hoist-variables@7.24.7:
++    resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
++    engines: {node: '>=6.9.0'}
++    dependencies:
++      '@babel/types': 7.24.7
      dev: true
  
-   /@babel/helper-module-imports/7.18.6:
-@@ -207,7 +230,7 @@ packages:
+   /@babel/helper-module-imports@7.18.6:
+@@ -251,7 +274,7 @@ packages:
        '@babel/helper-split-export-declaration': 7.18.6
        '@babel/helper-validator-identifier': 7.19.1
        '@babel/template': 7.18.10
@@ -169,41 +126,41 @@ index 57780fc..5b67df3 100644
        '@babel/types': 7.20.2
      transitivePeerDependencies:
        - supports-color
-@@ -232,16 +255,33 @@ packages:
+@@ -276,16 +299,33 @@ packages:
        '@babel/types': 7.20.2
      dev: true
  
-+  /@babel/helper-split-export-declaration/7.22.6:
-+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
++  /@babel/helper-split-export-declaration@7.24.7:
++    resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
 +    engines: {node: '>=6.9.0'}
 +    dependencies:
-+      '@babel/types': 7.23.0
++      '@babel/types': 7.24.7
 +    dev: true
 +
-   /@babel/helper-string-parser/7.19.4:
+   /@babel/helper-string-parser@7.19.4:
      resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
      engines: {node: '>=6.9.0'}
      dev: true
  
-+  /@babel/helper-string-parser/7.22.5:
-+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
++  /@babel/helper-string-parser@7.24.7:
++    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
 +    engines: {node: '>=6.9.0'}
 +    dev: true
 +
-   /@babel/helper-validator-identifier/7.19.1:
+   /@babel/helper-validator-identifier@7.19.1:
      resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
      engines: {node: '>=6.9.0'}
      dev: true
  
-+  /@babel/helper-validator-identifier/7.22.20:
-+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
++  /@babel/helper-validator-identifier@7.24.7:
++    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
 +    engines: {node: '>=6.9.0'}
 +    dev: true
 +
-   /@babel/helper-validator-option/7.18.6:
+   /@babel/helper-validator-option@7.18.6:
      resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
      engines: {node: '>=6.9.0'}
-@@ -252,7 +292,7 @@ packages:
+@@ -296,7 +336,7 @@ packages:
      engines: {node: '>=6.9.0'}
      dependencies:
        '@babel/template': 7.18.10
@@ -212,45 +169,46 @@ index 57780fc..5b67df3 100644
        '@babel/types': 7.20.2
      transitivePeerDependencies:
        - supports-color
-@@ -267,6 +307,15 @@ packages:
+@@ -311,6 +351,16 @@ packages:
        js-tokens: 4.0.0
      dev: true
  
-+  /@babel/highlight/7.22.20:
-+    resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
++  /@babel/highlight@7.24.7:
++    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
 +    engines: {node: '>=6.9.0'}
 +    dependencies:
-+      '@babel/helper-validator-identifier': 7.22.20
++      '@babel/helper-validator-identifier': 7.24.7
 +      chalk: 2.4.2
 +      js-tokens: 4.0.0
++      picocolors: 1.0.0
 +    dev: true
 +
-   /@babel/parser/7.20.3:
+   /@babel/parser@7.20.3:
      resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
      engines: {node: '>=6.0.0'}
-@@ -275,6 +324,14 @@ packages:
+@@ -319,6 +369,14 @@ packages:
        '@babel/types': 7.20.2
      dev: true
  
-+  /@babel/parser/7.23.0:
-+    resolution: {integrity: sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==}
++  /@babel/parser@7.24.7:
++    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
 +    engines: {node: '>=6.0.0'}
 +    hasBin: true
 +    dependencies:
-+      '@babel/types': 7.23.0
++      '@babel/types': 7.24.7
 +    dev: true
 +
-   /@babel/plugin-syntax-flow/7.18.6_@babel+core@7.20.2:
+   /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.20.2):
      resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
      engines: {node: '>=6.9.0'}
-@@ -321,18 +378,27 @@ packages:
+@@ -367,18 +425,27 @@ packages:
        '@babel/types': 7.20.2
      dev: true
  
--  /@babel/traverse/7.20.1:
+-  /@babel/traverse@7.20.1:
 -    resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
-+  /@babel/template/7.22.15:
-+    resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
++  /@babel/template@7.24.7:
++    resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
      engines: {node: '>=6.9.0'}
      dependencies:
 -      '@babel/code-frame': 7.18.6
@@ -261,70 +219,103 @@ index 57780fc..5b67df3 100644
 -      '@babel/helper-split-export-declaration': 7.18.6
 -      '@babel/parser': 7.20.3
 -      '@babel/types': 7.20.2
-+      '@babel/code-frame': 7.22.13
-+      '@babel/parser': 7.23.0
-+      '@babel/types': 7.23.0
++      '@babel/code-frame': 7.24.7
++      '@babel/parser': 7.24.7
++      '@babel/types': 7.24.7
 +    dev: true
 +
-+  /@babel/traverse/7.23.2:
++  /@babel/traverse@7.23.2:
 +    resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
 +    engines: {node: '>=6.9.0'}
 +    dependencies:
-+      '@babel/code-frame': 7.22.13
-+      '@babel/generator': 7.23.0
-+      '@babel/helper-environment-visitor': 7.22.20
-+      '@babel/helper-function-name': 7.23.0
-+      '@babel/helper-hoist-variables': 7.22.5
-+      '@babel/helper-split-export-declaration': 7.22.6
-+      '@babel/parser': 7.23.0
-+      '@babel/types': 7.23.0
-       debug: 4.3.4
++      '@babel/code-frame': 7.24.7
++      '@babel/generator': 7.24.7
++      '@babel/helper-environment-visitor': 7.24.7
++      '@babel/helper-function-name': 7.24.7
++      '@babel/helper-hoist-variables': 7.24.7
++      '@babel/helper-split-export-declaration': 7.24.7
++      '@babel/parser': 7.24.7
++      '@babel/types': 7.24.7
+       debug: 4.3.4(supports-color@8.1.1)
        globals: 11.12.0
      transitivePeerDependencies:
-@@ -348,6 +414,15 @@ packages:
+@@ -394,6 +461,15 @@ packages:
        to-fast-properties: 2.0.0
      dev: true
  
-+  /@babel/types/7.23.0:
-+    resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
++  /@babel/types@7.24.7:
++    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
 +    engines: {node: '>=6.9.0'}
 +    dependencies:
-+      '@babel/helper-string-parser': 7.22.5
-+      '@babel/helper-validator-identifier': 7.22.20
++      '@babel/helper-string-parser': 7.24.7
++      '@babel/helper-validator-identifier': 7.24.7
 +      to-fast-properties: 2.0.0
 +    dev: true
 +
-   /@colors/colors/1.5.0:
+   /@colors/colors@1.5.0:
      resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
      engines: {node: '>=0.1.90'}
-@@ -1078,12 +1153,6 @@ packages:
+@@ -475,6 +551,15 @@ packages:
+       '@jridgewell/trace-mapping': 0.3.17
+     dev: true
+ 
++  /@jridgewell/gen-mapping@0.3.5:
++    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
++    engines: {node: '>=6.0.0'}
++    dependencies:
++      '@jridgewell/set-array': 1.2.1
++      '@jridgewell/sourcemap-codec': 1.4.14
++      '@jridgewell/trace-mapping': 0.3.25
++    dev: true
++
+   /@jridgewell/resolve-uri@3.1.0:
+     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+     engines: {node: '>=6.0.0'}
+@@ -485,6 +570,11 @@ packages:
+     engines: {node: '>=6.0.0'}
+     dev: true
+ 
++  /@jridgewell/set-array@1.2.1:
++    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
++    engines: {node: '>=6.0.0'}
++    dev: true
++
+   /@jridgewell/source-map@0.3.2:
+     resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
+     dependencies:
+@@ -503,6 +593,13 @@ packages:
+       '@jridgewell/sourcemap-codec': 1.4.14
+     dev: true
+ 
++  /@jridgewell/trace-mapping@0.3.25:
++    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
++    dependencies:
++      '@jridgewell/resolve-uri': 3.1.0
++      '@jridgewell/sourcemap-codec': 1.4.14
++    dev: true
++
+   /@jridgewell/trace-mapping@0.3.9:
+     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+     dependencies:
+@@ -1161,12 +1258,6 @@ packages:
      engines: {node: '>=8'}
      dev: true
  
--  /bindings/1.5.0:
+-  /bindings@1.5.0:
 -    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 -    dependencies:
 -      file-uri-to-path: 1.0.0
 -    dev: true
 -
-   /bl/4.1.0:
+   /bl@4.1.0:
      resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
      dependencies:
-@@ -1102,7 +1171,7 @@ packages:
-     dependencies:
-       ansi-align: 2.0.0
-       camelcase: 4.1.0
--      chalk: 2.4.1
-+      chalk: 2.4.2
-       cli-boxes: 1.0.0
-       string-width: 2.1.1
-       term-size: 1.2.0
-@@ -1644,15 +1713,6 @@ packages:
+@@ -1714,15 +1805,6 @@ packages:
      resolution: {integrity: sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==}
      dev: true
  
--  /deasync/0.1.28:
--    resolution: {integrity: sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==}
+-  /deasync@0.1.29:
+-    resolution: {integrity: sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==}
 -    engines: {node: '>=0.11.0'}
 -    requiresBuild: true
 -    dependencies:
@@ -332,67 +323,45 @@ index 57780fc..5b67df3 100644
 -      node-addon-api: 1.7.2
 -    dev: true
 -
-   /debug/2.6.9:
+   /debug@2.6.9:
      resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
      peerDependencies:
-@@ -2308,7 +2368,7 @@ packages:
+@@ -2365,7 +2447,7 @@ packages:
      peerDependencies:
        eslint: ^3.17.0 || ^4 || ^5 || ^6 || ^7
      dependencies:
 -      '@babel/traverse': 7.20.1
 +      '@babel/traverse': 7.23.2
-       eslint: 8.28.0
+       eslint: 7.32.0
        eslint-plugin-react-native-globals: 0.1.2
      transitivePeerDependencies:
-@@ -2588,10 +2648,6 @@ packages:
+@@ -2651,10 +2733,6 @@ packages:
        flat-cache: 3.0.4
      dev: true
  
--  /file-uri-to-path/1.0.0:
+-  /file-uri-to-path@1.0.0:
 -    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 -    dev: true
 -
-   /filename-reserved-regex/2.0.0:
+   /filename-reserved-regex@2.0.0:
      resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
      engines: {node: '>=4'}
-@@ -3913,16 +3969,12 @@ packages:
+@@ -3998,10 +4076,6 @@ packages:
        semver: 7.3.8
      dev: true
  
--  /node-addon-api/1.7.2:
+-  /node-addon-api@1.7.2:
 -    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 -    dev: true
 -
-   /node-addon-api/3.2.1:
+   /node-addon-api@3.2.1:
      resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
      dev: true
+@@ -4917,6 +4991,7 @@ packages:
  
--  /node-addon-api/5.0.0:
--    resolution: {integrity: sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==}
-+  /node-addon-api/6.1.0:
-+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
-     dev: false
- 
-   /node-gyp-build/4.5.0:
-@@ -5523,7 +5575,7 @@ packages:
-     engines: {node: '>=4'}
+   /rimraf@3.0.2:
+     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
++    deprecated: Rimraf versions prior to v4 are no longer supported
+     hasBin: true
      dependencies:
-       boxen: 1.3.0
--      chalk: 2.4.1
-+      chalk: 2.4.2
-       configstore: 3.1.5
-       import-lazy: 2.1.0
-       is-ci: 1.2.1
-diff --git a/script/build.ts b/script/build.ts
-index c055ebc..693d914 100644
---- a/script/build.ts
-+++ b/script/build.ts
-@@ -78,7 +78,7 @@ function main() {
-     writeFileSync(clang_format_file, "")
-   }
- 
--  const cmake_configure = `cmake -S "${src_dir}" -B ./build ${build_options} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX="${libzmq_install_prefix}" -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_STATIC=ON -DBUILD_TESTS=OFF -DBUILD_SHARED=OFF -DWITH_DOCS=OFF -DWITH_LIBSODIUM=ON -DWITH_LIBSODIUM_STATIC=ON`
-+  const cmake_configure = `cmake -S "${src_dir}" -B ./build ${build_options} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX="${libzmq_install_prefix}" -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_STATIC=ON -DBUILD_TESTS=OFF -DBUILD_SHARED=OFF -DWITH_DOCS=OFF -DWITH_LIBSODIUM=OFF`
-   console.log(cmake_configure)
-   exec(cmake_configure, execOptions)
- 
+       glob: 7.2.3

--- a/build/patch.patch
+++ b/build/patch.patch
@@ -1,7 +1,16 @@
 diff --git a/package.json b/package.json
-index c9611cf..ae00b2d 100644
+index c9611cf..ed8f03a 100644
 --- a/package.json
 +++ b/package.json
+@@ -18,7 +18,7 @@
+   },
+   "homepage": "http://zeromq.github.io/zeromq.js/",
+   "dependencies": {
+-    "@aminya/node-gyp-build": "4.5.0-aminya.5",
++    "node-gyp-build": "^4.8.1",
+     "cross-env": "^7.0.3",
+     "node-addon-api": "^7.0.0",
+     "shelljs": "^0.8.5",
 @@ -35,7 +35,6 @@
      "@types/which": "^2.0.1",
      "benchmark": "^2.1.4",
@@ -10,29 +19,54 @@ index c9611cf..ae00b2d 100644
      "downlevel-dts": "^0.11.0",
      "electron-mocha": "^11.0.2",
      "eslint-config-atomic": "^1.18.1",
-@@ -59,7 +58,8 @@
+@@ -59,7 +58,9 @@
    "pnpm": {
      "overrides": {
        "typescript": "~4.9.3",
 -      "node-gyp": "10.0.1"
 +      "node-gyp": "10.0.1",
-+      "@babel/traverse": "7.23.2"
++      "@babel/traverse": "7.23.2",
++      "node-gyp-build": "^4.8.1"
      }
    },
    "engines": {
+@@ -79,7 +80,7 @@
+     "tsconfig.json"
+   ],
+   "scripts": {
+-    "install": "(shx test -f ./script/build.js || run-s build.js) && cross-env npm_config_build_from_source=true aminya-node-gyp-build",
++    "install": "(shx test -f ./script/build.js || run-s build.js) && cross-env npm_config_build_from_source=true node-gyp-build",
+     "clean": "shx rm -rf ./build ./lib/ ./prebuilds ./script/*.js ./script/*.js.map ./script/*.d.ts ./script/*.tsbuildinfo",
+     "clean.temp": "shx rm -rf ./tmp && shx mkdir -p ./tmp && shx touch ./tmp/.gitkeep",
+     "build.library.compat": "shx rm -rf ./lib/ts3.7 && downlevel-dts ./lib ./lib/ts3.7 --to=3.7",
 diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index 1acd1f1..e767a08 100644
+index 1acd1f1..91951cd 100644
 --- a/pnpm-lock.yaml
 +++ b/pnpm-lock.yaml
-@@ -7,6 +7,7 @@ settings:
+@@ -7,17 +7,19 @@ settings:
  overrides:
    typescript: ~4.9.3
    node-gyp: 10.0.1
 +  '@babel/traverse': 7.23.2
++  node-gyp-build: ^4.8.1
  
  dependencies:
-   '@aminya/node-gyp-build':
-@@ -56,9 +57,6 @@ devDependencies:
+-  '@aminya/node-gyp-build':
+-    specifier: 4.5.0-aminya.5
+-    version: 4.5.0-aminya.5
+   cross-env:
+     specifier: ^7.0.3
+     version: 7.0.3
+   node-addon-api:
+     specifier: ^7.0.0
+     version: 7.0.0
++  node-gyp-build:
++    specifier: ^4.8.1
++    version: 4.8.1
+   shelljs:
+     specifier: ^0.8.5
+     version: 0.8.5
+@@ -56,9 +58,6 @@ devDependencies:
    chai:
      specifier: ^4.3.7
      version: 4.3.7
@@ -42,7 +76,28 @@ index 1acd1f1..e767a08 100644
    downlevel-dts:
      specifier: ^0.11.0
      version: 0.11.0
-@@ -150,6 +148,14 @@ packages:
+@@ -124,11 +123,6 @@ packages:
+     engines: {node: '>=6'}
+     dev: true
+ 
+-  /@aminya/node-gyp-build@4.5.0-aminya.5:
+-    resolution: {integrity: sha512-TO7GldxDfSeSRNZVmhlm0liS2GX2o2Q/qTlcD3iD4ltTM6dir568LTRZ+ZDsDbLfMAkfhrbU+VuzNYImwYfczg==}
+-    hasBin: true
+-    dev: false
+-
+   /@ampproject/remapping@2.2.0:
+     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
+     engines: {node: '>=6.0.0'}
+@@ -140,7 +134,7 @@ packages:
+   /@babel/code-frame@7.12.11:
+     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
+     dependencies:
+-      '@babel/highlight': 7.18.6
++      '@babel/highlight': 7.24.7
+     dev: true
+ 
+   /@babel/code-frame@7.18.6:
+@@ -150,6 +144,14 @@ packages:
        '@babel/highlight': 7.18.6
      dev: true
  
@@ -57,7 +112,7 @@ index 1acd1f1..e767a08 100644
    /@babel/compat-data@7.20.1:
      resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
      engines: {node: '>=6.9.0'}
-@@ -167,7 +173,7 @@ packages:
+@@ -167,7 +169,7 @@ packages:
        '@babel/helpers': 7.20.1
        '@babel/parser': 7.20.3
        '@babel/template': 7.18.10
@@ -66,7 +121,7 @@ index 1acd1f1..e767a08 100644
        '@babel/types': 7.20.2
        convert-source-map: 1.9.0
        debug: 4.3.4(supports-color@8.1.1)
-@@ -201,6 +207,16 @@ packages:
+@@ -201,6 +203,16 @@ packages:
        jsesc: 2.5.2
      dev: true
  
@@ -83,7 +138,7 @@ index 1acd1f1..e767a08 100644
    /@babel/helper-compilation-targets@7.20.0(@babel/core@7.20.2):
      resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
      engines: {node: '>=6.9.0'}
-@@ -219,19 +235,26 @@ packages:
+@@ -219,19 +231,26 @@ packages:
      engines: {node: '>=6.9.0'}
      dev: true
  
@@ -117,7 +172,7 @@ index 1acd1f1..e767a08 100644
      dev: true
  
    /@babel/helper-module-imports@7.18.6:
-@@ -251,7 +274,7 @@ packages:
+@@ -251,7 +270,7 @@ packages:
        '@babel/helper-split-export-declaration': 7.18.6
        '@babel/helper-validator-identifier': 7.19.1
        '@babel/template': 7.18.10
@@ -126,7 +181,7 @@ index 1acd1f1..e767a08 100644
        '@babel/types': 7.20.2
      transitivePeerDependencies:
        - supports-color
-@@ -276,16 +299,33 @@ packages:
+@@ -276,16 +295,33 @@ packages:
        '@babel/types': 7.20.2
      dev: true
  
@@ -160,7 +215,7 @@ index 1acd1f1..e767a08 100644
    /@babel/helper-validator-option@7.18.6:
      resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
      engines: {node: '>=6.9.0'}
-@@ -296,7 +336,7 @@ packages:
+@@ -296,7 +332,7 @@ packages:
      engines: {node: '>=6.9.0'}
      dependencies:
        '@babel/template': 7.18.10
@@ -169,7 +224,7 @@ index 1acd1f1..e767a08 100644
        '@babel/types': 7.20.2
      transitivePeerDependencies:
        - supports-color
-@@ -311,6 +351,16 @@ packages:
+@@ -311,6 +347,16 @@ packages:
        js-tokens: 4.0.0
      dev: true
  
@@ -186,7 +241,7 @@ index 1acd1f1..e767a08 100644
    /@babel/parser@7.20.3:
      resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
      engines: {node: '>=6.0.0'}
-@@ -319,6 +369,14 @@ packages:
+@@ -319,6 +365,14 @@ packages:
        '@babel/types': 7.20.2
      dev: true
  
@@ -201,7 +256,7 @@ index 1acd1f1..e767a08 100644
    /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.20.2):
      resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
      engines: {node: '>=6.9.0'}
-@@ -367,18 +425,27 @@ packages:
+@@ -367,18 +421,27 @@ packages:
        '@babel/types': 7.20.2
      dev: true
  
@@ -239,7 +294,7 @@ index 1acd1f1..e767a08 100644
        debug: 4.3.4(supports-color@8.1.1)
        globals: 11.12.0
      transitivePeerDependencies:
-@@ -394,6 +461,15 @@ packages:
+@@ -394,6 +457,15 @@ packages:
        to-fast-properties: 2.0.0
      dev: true
  
@@ -255,7 +310,7 @@ index 1acd1f1..e767a08 100644
    /@colors/colors@1.5.0:
      resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
      engines: {node: '>=0.1.90'}
-@@ -475,6 +551,15 @@ packages:
+@@ -475,6 +547,15 @@ packages:
        '@jridgewell/trace-mapping': 0.3.17
      dev: true
  
@@ -271,7 +326,7 @@ index 1acd1f1..e767a08 100644
    /@jridgewell/resolve-uri@3.1.0:
      resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
      engines: {node: '>=6.0.0'}
-@@ -485,6 +570,11 @@ packages:
+@@ -485,6 +566,11 @@ packages:
      engines: {node: '>=6.0.0'}
      dev: true
  
@@ -283,7 +338,7 @@ index 1acd1f1..e767a08 100644
    /@jridgewell/source-map@0.3.2:
      resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
      dependencies:
-@@ -503,6 +593,13 @@ packages:
+@@ -503,6 +589,13 @@ packages:
        '@jridgewell/sourcemap-codec': 1.4.14
      dev: true
  
@@ -297,7 +352,7 @@ index 1acd1f1..e767a08 100644
    /@jridgewell/trace-mapping@0.3.9:
      resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
      dependencies:
-@@ -1161,12 +1258,6 @@ packages:
+@@ -1161,12 +1254,6 @@ packages:
      engines: {node: '>=8'}
      dev: true
  
@@ -310,7 +365,7 @@ index 1acd1f1..e767a08 100644
    /bl@4.1.0:
      resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
      dependencies:
-@@ -1714,15 +1805,6 @@ packages:
+@@ -1714,15 +1801,6 @@ packages:
      resolution: {integrity: sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==}
      dev: true
  
@@ -326,7 +381,7 @@ index 1acd1f1..e767a08 100644
    /debug@2.6.9:
      resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
      peerDependencies:
-@@ -2365,7 +2447,7 @@ packages:
+@@ -2365,7 +2443,7 @@ packages:
      peerDependencies:
        eslint: ^3.17.0 || ^4 || ^5 || ^6 || ^7
      dependencies:
@@ -335,7 +390,7 @@ index 1acd1f1..e767a08 100644
        eslint: 7.32.0
        eslint-plugin-react-native-globals: 0.1.2
      transitivePeerDependencies:
-@@ -2651,10 +2733,6 @@ packages:
+@@ -2651,10 +2729,6 @@ packages:
        flat-cache: 3.0.4
      dev: true
  
@@ -346,7 +401,7 @@ index 1acd1f1..e767a08 100644
    /filename-reserved-regex@2.0.0:
      resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
      engines: {node: '>=4'}
-@@ -3998,10 +4076,6 @@ packages:
+@@ -3998,10 +4072,6 @@ packages:
        semver: 7.3.8
      dev: true
  
@@ -357,7 +412,20 @@ index 1acd1f1..e767a08 100644
    /node-addon-api@3.2.1:
      resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
      dev: true
-@@ -4917,6 +4991,7 @@ packages:
+@@ -4010,10 +4080,9 @@ packages:
+     resolution: {integrity: sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==}
+     dev: false
+ 
+-  /node-gyp-build@4.5.0:
+-    resolution: {integrity: sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==}
++  /node-gyp-build@4.8.1:
++    resolution: {integrity: sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==}
+     hasBin: true
+-    dev: true
+ 
+   /node-gyp@10.0.1:
+     resolution: {integrity: sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==}
+@@ -4917,6 +4986,7 @@ packages:
  
    /rimraf@3.0.2:
      resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -365,3 +433,12 @@ index 1acd1f1..e767a08 100644
      hasBin: true
      dependencies:
        glob: 7.2.3
+@@ -5748,7 +5818,7 @@ packages:
+     requiresBuild: true
+     dependencies:
+       node-addon-api: 3.2.1
+-      node-gyp-build: 4.5.0
++      node-gyp-build: 4.8.1
+       setimmediate-napi: 1.0.6
+     dev: true
+ 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "zeromqRepo": "zeromq/zeromq.js",
-    "zeromqTag": "v6.0.0-beta.16"
+    "zeromqTag": "v6.0.0-beta.19"
 }


### PR DESCRIPTION
- Drops libsodium patch as the component is disabled in upstream, refs https://github.com/zeromq/zeromq.js/commit/82b838d06e13f4a7f1a68a1e4b9af1ff213cae84
- Use pnpm overrides to update dependencies
- Update alpine images to use node v18
- Update docker engine to v24 for using multi platform images
- Use official node-gyp-build and override to latest version to address EINVAL error related to child_process.spawn calls
- Update prebuildify to address EINVAL error
- Update output_node_file value for https://github.com/prebuild/prebuildify/commit/7b6dcbd0860a82db8804079ba55663affd9ae555