### PR TITLE
chore: migrate to 1ES release job

### DIFF
--- a/build/main.yml
+++ b/build/main.yml
@@ -25,7 +25,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
-      sourceAnalysisPool: 1es-windows-2019-x64
+      sourceAnalysisPool: 1es-windows-2022-x64
       tsa:
         enabled: true
     stages:
@@ -33,7 +33,7 @@ extends:
         jobs:
           - job: win32_x64
             pool:
-              name: 1es-windows-2019-x64
+              name: 1es-windows-2022-x64
               os: windows
             variables:
               - group: 'API Scan'
@@ -51,7 +51,7 @@ extends:
 
           - job: win32_arm64
             pool:
-              name: 1es-windows-2019-x64
+              name: 1es-windows-2022-x64
               os: windows
             templateContext:
               outputs:

--- a/build/main.yml
+++ b/build/main.yml
@@ -283,7 +283,38 @@ extends:
           os: linux
         condition: and(succeeded(), or(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq('${{ parameters.testGitHubRelease }}', 'true')))
         jobs:
-          - job: win32_x64
+          - job: publish
+            templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+              - input: pipelineArtifact
+                artifactName: win32-x64
+                targetPath: $(System.ArtifactsDirectory)/win32-x64
+              - input: pipelineArtifact
+                artifactName: win32-arm64
+                targetPath: $(System.ArtifactsDirectory)/win32-arm64
+              - input: pipelineArtifact
+                artifactName: darwin-x64
+                targetPath: $(System.ArtifactsDirectory)/darwin-x64
+              - input: pipelineArtifact
+                artifactName: darwin-arm64
+                targetPath: $(System.ArtifactsDirectory)/darwin-arm64
+              - input: pipelineArtifact
+                artifactName: linux-x64
+                targetPath: $(System.ArtifactsDirectory)/linux-x64
+              - input: pipelineArtifact
+                artifactName: linux-arm64-glibc
+                targetPath: $(System.ArtifactsDirectory)/linux-arm64-glibc
+              - input: pipelineArtifact
+                artifactName: linux-armhf-glibc
+                targetPath: $(System.ArtifactsDirectory)/linux-armhf-glibc
+              - input: pipelineArtifact
+                artifactName: alpine-x64-musl
+                targetPath: $(System.ArtifactsDirectory)/alpine-x64-musl
+              - input: pipelineArtifact
+                artifactName: alpine-arm64-musl
+                targetPath: $(System.ArtifactsDirectory)/alpine-arm64-musl
             steps:
               - template: build/publish.yml@self
                 parameters:

--- a/build/publish.yml
+++ b/build/publish.yml
@@ -2,10 +2,6 @@ parameters:
   testGitHubRelease: false
 
 steps:
-- task: DownloadPipelineArtifact@2
-  inputs:
-    path: '$(System.ArtifactsDirectory)'
-
 - bash: ls -LR
   displayName: List Files
   workingDirectory: $(System.ArtifactsDirectory)
@@ -24,29 +20,29 @@ steps:
     archiveType: 'zip'
     archiveFile: '$(System.ArtifactsDirectory)/linux-x64.zip'
 
-- task: GitHubRelease@0
+- task: GitHubRelease@1
   condition: eq('${{ parameters.testGitHubRelease }}', 'false')
   inputs:
     gitHubConnection: 'zeromq-prebuilt'
     repositoryName: '$(Build.Repository.Name)'
     action: 'edit'
     target: '$(Build.SourceVersion)'
-    tagSource: 'auto'
+    tagSource: 'userSpecifiedTag'
     tag: '$(Build.SourceBranchName)'
     assets: '$(System.ArtifactsDirectory)/**/*.zip'
     assetUploadMode: 'replace'
     addChangeLog: true
 
-- task: GitHubRelease@0
+- task: GitHubRelease@1
   condition: eq('${{ parameters.testGitHubRelease }}', 'true')
   inputs:
     gitHubConnection: 'zeromq-prebuilt'
     repositoryName: '$(Build.Repository.Name)'
     action: 'edit'
     target: '$(Build.SourceVersion)'
-    tagSource: 'manual'
-    isDraft: true
+    tagSource: 'userSpecifiedTag'
     tag: 'Test'
+    isDraft: true
     assets: '$(System.ArtifactsDirectory)/**/*.zip'
     assetUploadMode: 'replace'
     addChangeLog: false


### PR DESCRIPTION
Onboards onto the 1ES release job and bumps some other pipeline properties.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=303197&view=results