### PR TITLE
chore: publish symbols for downstream builds

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -128,7 +128,7 @@ steps:
 - task: 1ES.PublishPipelineArtifact@1
   inputs:
     targetPath: $(Agent.TempDirectory)/apiscan/zeromq.js/build/Release
-    artifactName: zeromq-prebuilt-symbols
+    artifactName: apiscan-symbols
   displayName: Publish Symbols Backup
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -119,21 +119,17 @@ steps:
 - task: PublishSymbols@2
   inputs:
     IndexSources: false # Unsupported source provider 'GitHub' for source indexing.
-    SymbolsFolder: $(Agent.TempDirectory)/apiscan
+    SymbolsFolder: $(Agent.TempDirectory)/apiscan/zeromq.js/build/Release
     SearchPattern: '**\*.pdb'
     SymbolServerType: TeamServices
-    ArtifactServices.Symbol.AccountName: microsoft
-    ArtifactServices.Symbol.PAT: $(System.AccessToken)
-    ArtifactServices.Symbol.UseAAD: false
   displayName: Publish Symbols
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
 
 - task: 1ES.PublishPipelineArtifact@1
   inputs:
-    targetPath: $(Agent.TempDirectory)/apiscan
-    artifactName: ScannedFiles
-    sbomEnabled: false
-  displayName: Publish scanned files
+    targetPath: $(Agent.TempDirectory)/apiscan/zeromq.js/build/Release
+    artifactName: zeromq-prebuilt-symbols
+  displayName: Publish Symbols Backup
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
 
 - task: APIScan@2
@@ -141,7 +137,7 @@ steps:
     softwareFolder: $(Agent.TempDirectory)/apiscan
     softwareName: 'zeromq'
     softwareVersionNum: '1'
-    symbolsFolder: 'srv*https://symweb.azurefd.net;$(Agent.TempDirectory)/apiscan'
+    symbolsFolder: 'srv*https://symweb.azurefd.net;$(Agent.TempDirectory)/apiscan/zeromq.js/build/Release'
     isLargeApp: false
     toolVersion: 'Latest'
     azureSubscription: 'vscode-apiscan'

--- a/build/build.yml
+++ b/build/build.yml
@@ -128,6 +128,14 @@ steps:
   displayName: Publish Symbols
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
 
+- task: 1ES.PublishPipelineArtifact@1
+  inputs:
+    targetPath: $(Agent.TempDirectory)/apiscan
+    artifactName: ScannedFiles
+    sbomEnabled: false
+  displayName: Publish scanned files
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq('${{ parameters.ARCH }}', 'x64'))
+
 - task: APIScan@2
   inputs:
     softwareFolder: $(Agent.TempDirectory)/apiscan

--- a/build/publish.yml
+++ b/build/publish.yml
@@ -33,6 +33,7 @@ steps:
     assetUploadMode: 'replace'
     addChangeLog: true
 
+# Indicate to downstream pipelines running APIScan that this build contains symbols we want to use.
 - script: echo "##vso[build.addbuildtag]publishes-apiscan-symbols"
   displayName: Add build tag
   condition: eq('${{ parameters.testGitHubRelease }}', 'false')

--- a/build/publish.yml
+++ b/build/publish.yml
@@ -33,7 +33,7 @@ steps:
     assetUploadMode: 'replace'
     addChangeLog: true
 
-- script: echo "##vso[build.addbuildtag]$(Build.SourceBranchName)"
+- script: echo "##vso[build.addbuildtag]publishes-apiscan-symbols"
   displayName: Add build tag
   condition: eq('${{ parameters.testGitHubRelease }}', 'false')
 

--- a/build/publish.yml
+++ b/build/publish.yml
@@ -20,29 +20,32 @@ steps:
     archiveType: 'zip'
     archiveFile: '$(System.ArtifactsDirectory)/linux-x64.zip'
 
-- task: GitHubRelease@1
-  condition: eq('${{ parameters.testGitHubRelease }}', 'false')
-  inputs:
-    gitHubConnection: oauth
-    repositoryName: '$(Build.Repository.Name)'
-    action: 'edit'
-    target: '$(Build.SourceVersion)'
-    tagSource: 'userSpecifiedTag'
-    tag: '$(Build.SourceBranchName)'
-    assets: '$(System.ArtifactsDirectory)/**/*.zip'
-    assetUploadMode: 'replace'
-    addChangeLog: true
+- {{ if eq(parameters.testGitHubRelease, 'false') }}:
+  - task: GitHubRelease@1
+    inputs:
+      gitHubConnection: oauth
+      repositoryName: '$(Build.Repository.Name)'
+      action: 'edit'
+      target: '$(Build.SourceVersion)'
+      tagSource: 'userSpecifiedTag'
+      tag: '$(Build.SourceBranchName)'
+      assets: '$(System.ArtifactsDirectory)/**/*.zip'
+      assetUploadMode: 'replace'
+      addChangeLog: true
 
-- task: GitHubRelease@1
-  condition: eq('${{ parameters.testGitHubRelease }}', 'true')
-  inputs:
-    gitHubConnection: oauth
-    repositoryName: '$(Build.Repository.Name)'
-    action: 'edit'
-    target: '$(Build.SourceVersion)'
-    tagSource: 'userSpecifiedTag'
-    tag: 'Test'
-    isDraft: true
-    assets: '$(System.ArtifactsDirectory)/**/*.zip'
-    assetUploadMode: 'replace'
-    addChangeLog: false
+  - script: echo "##vso[build.addbuildtag]$(Build.SourceBranchName)"
+    displayName: Add build tag
+
+- {{ else }}:
+  - task: GitHubRelease@1
+    inputs:
+      gitHubConnection: oauth
+      repositoryName: '$(Build.Repository.Name)'
+      action: 'edit'
+      target: '$(Build.SourceVersion)'
+      tagSource: 'userSpecifiedTag'
+      tag: 'Test'
+      isDraft: true
+      assets: '$(System.ArtifactsDirectory)/**/*.zip'
+      assetUploadMode: 'replace'
+      addChangeLog: false

--- a/build/publish.yml
+++ b/build/publish.yml
@@ -20,32 +20,33 @@ steps:
     archiveType: 'zip'
     archiveFile: '$(System.ArtifactsDirectory)/linux-x64.zip'
 
-- {{ if eq(parameters.testGitHubRelease, 'false') }}:
-  - task: GitHubRelease@1
-    inputs:
-      gitHubConnection: oauth
-      repositoryName: '$(Build.Repository.Name)'
-      action: 'edit'
-      target: '$(Build.SourceVersion)'
-      tagSource: 'userSpecifiedTag'
-      tag: '$(Build.SourceBranchName)'
-      assets: '$(System.ArtifactsDirectory)/**/*.zip'
-      assetUploadMode: 'replace'
-      addChangeLog: true
+- task: GitHubRelease@1
+  condition: eq('${{ parameters.testGitHubRelease }}', 'false')
+  inputs:
+    gitHubConnection: oauth
+    repositoryName: '$(Build.Repository.Name)'
+    action: 'edit'
+    target: '$(Build.SourceVersion)'
+    tagSource: 'userSpecifiedTag'
+    tag: '$(Build.SourceBranchName)'
+    assets: '$(System.ArtifactsDirectory)/**/*.zip'
+    assetUploadMode: 'replace'
+    addChangeLog: true
 
-  - script: echo "##vso[build.addbuildtag]$(Build.SourceBranchName)"
-    displayName: Add build tag
+- script: echo "##vso[build.addbuildtag]$(Build.SourceBranchName)"
+  displayName: Add build tag
+  condition: eq('${{ parameters.testGitHubRelease }}', 'false')
 
-- {{ else }}:
-  - task: GitHubRelease@1
-    inputs:
-      gitHubConnection: oauth
-      repositoryName: '$(Build.Repository.Name)'
-      action: 'edit'
-      target: '$(Build.SourceVersion)'
-      tagSource: 'userSpecifiedTag'
-      tag: 'Test'
-      isDraft: true
-      assets: '$(System.ArtifactsDirectory)/**/*.zip'
-      assetUploadMode: 'replace'
-      addChangeLog: false
+- task: GitHubRelease@1
+  condition: eq('${{ parameters.testGitHubRelease }}', 'true')
+  inputs:
+    gitHubConnection: oauth
+    repositoryName: '$(Build.Repository.Name)'
+    action: 'edit'
+    target: '$(Build.SourceVersion)'
+    tagSource: 'userSpecifiedTag'
+    tag: 'Test'
+    isDraft: true
+    assets: '$(System.ArtifactsDirectory)/**/*.zip'
+    assetUploadMode: 'replace'
+    addChangeLog: false


### PR DESCRIPTION
Symbol publishing is tougher than I thought. To work around the confusing documentation on it, I plan to publish the symbols as pipeline artifacts for now for downstream pipelines to consume.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=307024&view=results